### PR TITLE
docs: Add DocC documentation catalog

### DIFF
--- a/Sources/CutiE/CutiE.docc/CutiE.md
+++ b/Sources/CutiE/CutiE.docc/CutiE.md
@@ -1,0 +1,92 @@
+# ``CutiE``
+
+Character-driven feedback SDK for iOS apps.
+
+## Overview
+
+Cuti-E brings friendly mascot characters to your app's feedback and support experience. Instead of boring forms, users interact with cute characters that make giving feedback feel personal and engaging.
+
+### Features
+
+- **Feedback Collection** - Collect user feedback through an engaging character interface
+- **Push Notifications** - Send personalized messages from your mascot character
+- **Subscription Management** - Handle in-app purchases with StoreKit 2
+- **Real-time Updates** - Sync feedback status and responses instantly
+
+## Getting Started
+
+### Installation
+
+Add Cuti-E to your project using Swift Package Manager:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/cuti-e/ios-sdk", from: "1.0.0")
+]
+```
+
+### Configuration
+
+Configure Cuti-E in your app's initialization:
+
+```swift
+import CutiE
+
+@main
+struct MyApp: App {
+    init() {
+        CutiE.shared.configure(
+            apiKey: "your-api-key",
+            appID: "your-app-id"
+        )
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+### Showing the Feedback View
+
+Present the feedback interface to your users:
+
+```swift
+import SwiftUI
+import CutiE
+
+struct SettingsView: View {
+    @State private var showFeedback = false
+
+    var body: some View {
+        Button("Send Feedback") {
+            showFeedback = true
+        }
+        .sheet(isPresented: $showFeedback) {
+            CutiEFeedbackView()
+        }
+    }
+}
+```
+
+## Topics
+
+### Essentials
+
+- ``CutiE``
+- ``CutiEConfiguration``
+
+### Views
+
+- ``CutiEFeedbackView``
+- ``CutiEInboxView``
+
+### Push Notifications
+
+- ``CutiEPushNotifications``
+
+### Subscriptions
+
+- ``CutiESubscriptionManager``

--- a/Sources/CutiE/CutiE.docc/GettingStarted.md
+++ b/Sources/CutiE/CutiE.docc/GettingStarted.md
@@ -1,0 +1,97 @@
+# Getting Started with Cuti-E
+
+Set up Cuti-E in your iOS app in minutes.
+
+## Overview
+
+This guide walks you through adding Cuti-E to your app, configuring it with your credentials, and showing the feedback interface to users.
+
+## Prerequisites
+
+- iOS 15.0+ / macOS 12.0+
+- Xcode 15.0+
+- A Cuti-E account with API credentials
+
+## Step 1: Add the Package
+
+Add Cuti-E using Swift Package Manager in Xcode:
+
+1. File → Add Package Dependencies
+2. Enter: `https://github.com/cuti-e/ios-sdk`
+3. Select version 1.0.0 or later
+
+Or add to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/cuti-e/ios-sdk", from: "1.0.0")
+]
+```
+
+## Step 2: Configure the SDK
+
+Initialize Cuti-E when your app launches:
+
+```swift
+import CutiE
+
+@main
+struct MyApp: App {
+    init() {
+        CutiE.shared.configure(
+            apiKey: "your-api-key",
+            appID: "your-app-id"
+        )
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+> Important: Never commit your API key to source control. Use environment variables or a secrets manager.
+
+## Step 3: Show the Feedback View
+
+Present ``CutiEFeedbackView`` when users want to send feedback:
+
+```swift
+struct SettingsView: View {
+    @State private var showFeedback = false
+
+    var body: some View {
+        List {
+            Button("Send Feedback") {
+                showFeedback = true
+            }
+        }
+        .sheet(isPresented: $showFeedback) {
+            CutiEFeedbackView()
+        }
+    }
+}
+```
+
+## Step 4: Enable Push Notifications (Optional)
+
+To receive responses from your mascot character:
+
+```swift
+// In your AppDelegate or App init
+CutiE.shared.pushNotifications.registerForRemoteNotifications()
+
+// Handle device token
+func application(_ application: UIApplication,
+                 didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    CutiE.shared.pushNotifications.setDeviceToken(deviceToken)
+}
+```
+
+## Next Steps
+
+- Learn about ``CutiEInboxView`` for showing message history
+- Set up ``CutiESubscriptionManager`` for premium features
+- Customize the character appearance in your admin dashboard


### PR DESCRIPTION
## Summary
Add DocC documentation for the SDK.

**Contents:**
- `CutiE.md` - Main landing page with overview, features, and quick start
- `GettingStarted.md` - Step-by-step setup guide

Documentation will be built automatically by CI and uploaded as an artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)