### PR TITLE
fix: Add diagnostic logging for 401 debugging

### DIFF
--- a/Sources/CutiE/CutiE.swift
+++ b/Sources/CutiE/CutiE.swift
@@ -51,6 +51,19 @@ public class CutiE {
     ///   - appId: Your App ID from the admin dashboard (created in Settings > Apps)
     ///   - apiURL: Optional custom API URL (defaults to production)
     public func configure(apiKey: String, appId: String, apiURL: String = "https://api.cuti-e.com") {
+        // Diagnostic logging
+        #if DEBUG
+        let apiKeyPreview = apiKey.isEmpty ? "(EMPTY!)" : String(apiKey.prefix(8)) + "..."
+        NSLog("[CutiE] Configuring SDK...")
+        NSLog("[CutiE]   API Key: %@", apiKeyPreview)
+        NSLog("[CutiE]   App ID: %@", appId.isEmpty ? "(EMPTY!)" : appId)
+        NSLog("[CutiE]   API URL: %@", apiURL)
+        NSLog("[CutiE]   Device ID: %@", deviceID)
+        if apiKey.isEmpty {
+            NSLog("[CutiE] ⚠️ WARNING: API key is empty! Requests will fail with 401.")
+        }
+        #endif
+
         self.configuration = CutiEConfiguration(
             apiKey: apiKey,
             apiURL: apiURL,


### PR DESCRIPTION
## Summary
Adds debug logging to help diagnose why 401 errors occur on some devices but not others.

## Logging Added (DEBUG builds only)

**SDK Configuration:**
```
[CutiE] Configuring SDK...
[CutiE]   API Key: abc12345...
[CutiE]   App ID: app_xyz
[CutiE]   API URL: https://api.cuti-e.com
[CutiE]   Device ID: device_xxxx
```

**API Requests:**
```
[CutiE] Request: POST /v1/conversations
[CutiE] API Key: abc12345... | Device ID: device_xxxx
[CutiE] Has Device Token: no
```

**401 Errors:**
```
[CutiE] HTTP 401 Error: {"error":"Invalid API key"}
[CutiE] 401 with device token - clearing and retrying with API key
```

## Why This Helps

If the API key is empty:
```
[CutiE]   API Key: (EMPTY!)
[CutiE] ⚠️ WARNING: API key is empty! Requests will fail with 401.
```

This will identify if the issue is:
1. Empty API key (Info.plist not bundled correctly)
2. Device token rejection without proper retry
3. Actual API key validation failure on backend

## Testing
Run the app from Xcode and check Console.app for `[CutiE]` logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)