### PR TITLE
feat: Add anonymous device registration - API key no longer required

### DIFF
--- a/Sources/CutiE/CutiESubscriptionManager.swift
+++ b/Sources/CutiE/CutiESubscriptionManager.swift
@@ -289,8 +289,11 @@ extension CutiEAPIClient {
         var request = URLRequest(url: URL(string: endpoint)!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(configuration.apiKey, forHTTPHeaderField: "X-API-Key")
+        request.setValue(configuration.appId, forHTTPHeaderField: "X-App-ID")
         request.setValue(configuration.deviceID, forHTTPHeaderField: "X-Device-ID")
+        if let apiKey = configuration.apiKey {
+            request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
 
         // Add device secret
         let secret = generateDeviceSecret()
@@ -324,8 +327,11 @@ extension CutiEAPIClient {
 
         var request = URLRequest(url: URL(string: endpoint)!)
         request.httpMethod = "GET"
-        request.setValue(configuration.apiKey, forHTTPHeaderField: "X-API-Key")
+        request.setValue(configuration.appId, forHTTPHeaderField: "X-App-ID")
         request.setValue(configuration.deviceID, forHTTPHeaderField: "X-Device-ID")
+        if let apiKey = configuration.apiKey {
+            request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
 
         let secret = generateDeviceSecret()
         request.setValue(secret, forHTTPHeaderField: "X-Device-Secret")


### PR DESCRIPTION
## Summary
- Add new `configure(appId:)` method (recommended for new integrations)
- Deprecate `configure(apiKey:appId:)` method (still works for migration)
- Make apiKey optional in CutiEConfiguration
- Update API client to use App ID header for authentication
- Maintain backward compatibility with existing integrations

## Migration
Replace:
```swift
CutiE.shared.configure(apiKey: "xxx", appId: "app_xxx")
```

With:
```swift
CutiE.shared.configure(appId: "app_xxx")
```

## Breaking Changes
None - existing code using API key continues to work.

## Test plan
- [x] Verify SDK builds successfully
- [x] Verify new `configure(appId:)` method works
- [x] Verify deprecated method still works
- [ ] Test with real device against production backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)