### PR TITLE
Release v1.0.103 - App Attest Support

### DIFF
--- a/Tests/CutiETests/CutiEAPIClientTests.swift
+++ b/Tests/CutiETests/CutiEAPIClientTests.swift
@@ -118,10 +118,11 @@ final class CutiEAPIIntegrationTests: XCTestCase {
         )
     }
 
-    func testCreateConversation() {
-        guard cutiE.configuration != nil else {
-            // Skip if not configured (no test API key)
-            return
+    func testCreateConversation() throws {
+        // Skip if test credentials are not set via environment variables
+        guard ProcessInfo.processInfo.environment["CUTIE_TEST_API_KEY"] != nil,
+              ProcessInfo.processInfo.environment["CUTIE_TEST_APP_ID"] != nil else {
+            throw XCTSkip("Skipping integration test: CUTIE_TEST_API_KEY and CUTIE_TEST_APP_ID environment variables not set")
         }
 
         let expectation = XCTestExpectation(description: "Create conversation")

--- a/Tests/CutiETests/DeviceLinkingTests.swift
+++ b/Tests/CutiETests/DeviceLinkingTests.swift
@@ -1,0 +1,284 @@
+import XCTest
+@testable import CutiE
+
+final class DeviceLinkingTests: XCTestCase {
+
+    // MARK: - LinkTokenResponse Tests
+
+    func testLinkTokenResponseDecoding() throws {
+        let json = """
+        {
+            "link_token": "lt_abc123",
+            "expires_at": 1700000000000,
+            "expires_in": 300,
+            "has_existing_group": false
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkTokenResponse.self, from: json)
+
+        XCTAssertEqual(response.linkToken, "lt_abc123")
+        XCTAssertEqual(response.expiresAt, 1700000000000)
+        XCTAssertEqual(response.expiresIn, 300)
+        XCTAssertFalse(response.hasExistingGroup)
+    }
+
+    func testLinkTokenResponseWithExistingGroup() throws {
+        let json = """
+        {
+            "link_token": "lt_def456",
+            "expires_at": 1700000000000,
+            "expires_in": 300,
+            "has_existing_group": true
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkTokenResponse.self, from: json)
+
+        XCTAssertTrue(response.hasExistingGroup)
+    }
+
+    func testLinkTokenExpirationDate() {
+        // Manually create the response to test date conversion
+        let json = """
+        {
+            "link_token": "lt_test",
+            "expires_at": 1700000000000,
+            "expires_in": 300,
+            "has_existing_group": false
+        }
+        """.data(using: .utf8)!
+
+        let response = try! JSONDecoder().decode(LinkTokenResponse.self, from: json)
+        let expectedDate = Date(timeIntervalSince1970: 1700000000)
+        XCTAssertEqual(response.expirationDate, expectedDate)
+    }
+
+    // MARK: - LinkConfirmResponse Tests
+
+    func testLinkConfirmResponseDecoding() throws {
+        let json = """
+        {
+            "success": true,
+            "group_id": "grp_xyz789",
+            "message": "Device linked successfully"
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkConfirmResponse.self, from: json)
+
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.groupId, "grp_xyz789")
+        XCTAssertEqual(response.message, "Device linked successfully")
+    }
+
+    func testLinkConfirmResponseFailure() throws {
+        let json = """
+        {
+            "success": false,
+            "group_id": "",
+            "message": "Token expired"
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkConfirmResponse.self, from: json)
+
+        XCTAssertFalse(response.success)
+        XCTAssertEqual(response.message, "Token expired")
+    }
+
+    // MARK: - LinkTokenStatus Tests
+
+    func testLinkTokenStatusRawValues() {
+        XCTAssertEqual(LinkTokenStatus.pending.rawValue, "pending")
+        XCTAssertEqual(LinkTokenStatus.confirmed.rawValue, "confirmed")
+        XCTAssertEqual(LinkTokenStatus.expired.rawValue, "expired")
+    }
+
+    func testLinkTokenStatusDecoding() throws {
+        let pending = try JSONDecoder().decode(LinkTokenStatus.self, from: "\"pending\"".data(using: .utf8)!)
+        XCTAssertEqual(pending, .pending)
+
+        let confirmed = try JSONDecoder().decode(LinkTokenStatus.self, from: "\"confirmed\"".data(using: .utf8)!)
+        XCTAssertEqual(confirmed, .confirmed)
+
+        let expired = try JSONDecoder().decode(LinkTokenStatus.self, from: "\"expired\"".data(using: .utf8)!)
+        XCTAssertEqual(expired, .expired)
+    }
+
+    // MARK: - LinkStatusResponse Tests
+
+    func testLinkStatusResponsePending() throws {
+        let json = """
+        {
+            "status": "pending",
+            "link_token": "lt_abc123",
+            "expires_at": 1700000000000
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkStatusResponse.self, from: json)
+
+        XCTAssertEqual(response.status, .pending)
+        XCTAssertEqual(response.linkToken, "lt_abc123")
+        XCTAssertNil(response.groupId)
+        XCTAssertNil(response.targetDeviceName)
+        XCTAssertNil(response.confirmedAt)
+        XCTAssertEqual(response.expiresAt, 1700000000000)
+    }
+
+    func testLinkStatusResponseConfirmed() throws {
+        let json = """
+        {
+            "status": "confirmed",
+            "link_token": "lt_abc123",
+            "group_id": "grp_xyz",
+            "target_device_name": "John's iPad",
+            "confirmed_at": 1700000050000
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkStatusResponse.self, from: json)
+
+        XCTAssertEqual(response.status, .confirmed)
+        XCTAssertEqual(response.groupId, "grp_xyz")
+        XCTAssertEqual(response.targetDeviceName, "John's iPad")
+        XCTAssertEqual(response.confirmedAt, 1700000050000)
+    }
+
+    func testLinkStatusResponseExpired() throws {
+        let json = """
+        {
+            "status": "expired",
+            "link_token": "lt_abc123"
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkStatusResponse.self, from: json)
+
+        XCTAssertEqual(response.status, .expired)
+    }
+
+    // MARK: - LinkedDevice Tests
+
+    func testLinkedDeviceDecoding() throws {
+        let json = """
+        {
+            "device_id": "device_abc123",
+            "device_name": "John's iPhone",
+            "joined_at": 1700000000000,
+            "is_primary": true,
+            "is_current": true
+        }
+        """.data(using: .utf8)!
+
+        let device = try JSONDecoder().decode(LinkedDevice.self, from: json)
+
+        XCTAssertEqual(device.deviceId, "device_abc123")
+        XCTAssertEqual(device.deviceName, "John's iPhone")
+        XCTAssertEqual(device.joinedAt, 1700000000000)
+        XCTAssertTrue(device.isPrimary)
+        XCTAssertTrue(device.isCurrent)
+    }
+
+    func testLinkedDeviceId() throws {
+        let json = """
+        {
+            "device_id": "device_xyz",
+            "device_name": "Test Device",
+            "joined_at": 1700000000000,
+            "is_primary": false,
+            "is_current": false
+        }
+        """.data(using: .utf8)!
+
+        let device = try JSONDecoder().decode(LinkedDevice.self, from: json)
+
+        // Identifiable conformance: id should return deviceId
+        XCTAssertEqual(device.id, "device_xyz")
+        XCTAssertEqual(device.id, device.deviceId)
+    }
+
+    func testLinkedDeviceJoinedDate() throws {
+        let json = """
+        {
+            "device_id": "device_test",
+            "device_name": "Test",
+            "joined_at": 1700000000000,
+            "is_primary": false,
+            "is_current": false
+        }
+        """.data(using: .utf8)!
+
+        let device = try JSONDecoder().decode(LinkedDevice.self, from: json)
+        let expectedDate = Date(timeIntervalSince1970: 1700000000)
+        XCTAssertEqual(device.joinedDate, expectedDate)
+    }
+
+    func testLinkedDeviceSecondaryDevice() throws {
+        let json = """
+        {
+            "device_id": "device_secondary",
+            "device_name": "Secondary Device",
+            "joined_at": 1700000000000,
+            "is_primary": false,
+            "is_current": true
+        }
+        """.data(using: .utf8)!
+
+        let device = try JSONDecoder().decode(LinkedDevice.self, from: json)
+
+        XCTAssertFalse(device.isPrimary)
+        XCTAssertTrue(device.isCurrent)
+    }
+
+    // MARK: - LinkedDevicesResponse Tests
+
+    func testLinkedDevicesResponseNotLinked() throws {
+        let json = """
+        {
+            "linked": false,
+            "devices": []
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkedDevicesResponse.self, from: json)
+
+        XCTAssertFalse(response.linked)
+        XCTAssertNil(response.groupId)
+        XCTAssertTrue(response.devices.isEmpty)
+    }
+
+    func testLinkedDevicesResponseWithDevices() throws {
+        let json = """
+        {
+            "linked": true,
+            "group_id": "grp_123",
+            "devices": [
+                {
+                    "device_id": "device_1",
+                    "device_name": "iPhone",
+                    "joined_at": 1700000000000,
+                    "is_primary": true,
+                    "is_current": true
+                },
+                {
+                    "device_id": "device_2",
+                    "device_name": "iPad",
+                    "joined_at": 1700000050000,
+                    "is_primary": false,
+                    "is_current": false
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(LinkedDevicesResponse.self, from: json)
+
+        XCTAssertTrue(response.linked)
+        XCTAssertEqual(response.groupId, "grp_123")
+        XCTAssertEqual(response.devices.count, 2)
+        XCTAssertEqual(response.devices[0].deviceName, "iPhone")
+        XCTAssertEqual(response.devices[1].deviceName, "iPad")
+    }
+}

--- a/Tests/CutiETests/ErrorTests.swift
+++ b/Tests/CutiETests/ErrorTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import CutiE
+
+final class ErrorTests: XCTestCase {
+
+    // MARK: - CutiEError Tests
+
+    func testNotConfiguredError() {
+        let error = CutiEError.notConfigured
+        XCTAssertEqual(error.errorDescription, "CutiE is not configured. Call CutiE.shared.configure() first.")
+    }
+
+    func testInvalidAPIKeyError() {
+        let error = CutiEError.invalidAPIKey
+        XCTAssertEqual(error.errorDescription, "Invalid API key")
+    }
+
+    func testNetworkError() {
+        struct MockError: Error, LocalizedError {
+            var errorDescription: String? { "Connection failed" }
+        }
+
+        let underlyingError = MockError()
+        let error = CutiEError.networkError(underlyingError)
+
+        XCTAssertTrue(error.errorDescription?.contains("Network error") ?? false)
+        XCTAssertTrue(error.errorDescription?.contains("Connection failed") ?? false)
+    }
+
+    func testServerError() {
+        let error = CutiEError.serverError(500, "Internal server error")
+        XCTAssertEqual(error.errorDescription, "Server error (500): Internal server error")
+    }
+
+    func testServerErrorVariousCodes() {
+        let error400 = CutiEError.serverError(400, "Bad request")
+        XCTAssertTrue(error400.errorDescription?.contains("400") ?? false)
+
+        let error401 = CutiEError.serverError(401, "Unauthorized")
+        XCTAssertTrue(error401.errorDescription?.contains("401") ?? false)
+
+        let error403 = CutiEError.serverError(403, "Forbidden")
+        XCTAssertTrue(error403.errorDescription?.contains("403") ?? false)
+
+        let error404 = CutiEError.serverError(404, "Not found")
+        XCTAssertTrue(error404.errorDescription?.contains("404") ?? false)
+    }
+
+    func testDecodingErrorWithDetails() {
+        let error = CutiEError.decodingError("Missing required field: conversation_id")
+        XCTAssertEqual(error.errorDescription, "Missing required field: conversation_id")
+    }
+
+    func testDecodingErrorWithoutDetails() {
+        let error = CutiEError.decodingError(nil)
+        XCTAssertEqual(error.errorDescription, "Failed to decode server response")
+    }
+
+    func testDecodingErrorDefault() {
+        let error = CutiEError.decodingError()
+        XCTAssertEqual(error.errorDescription, "Failed to decode server response")
+    }
+
+    func testInvalidRequestError() {
+        let error = CutiEError.invalidRequest
+        XCTAssertEqual(error.errorDescription, "Invalid request")
+    }
+
+    // MARK: - LocalizedError Conformance
+
+    func testErrorsConformToLocalizedError() {
+        let errors: [CutiEError] = [
+            .notConfigured,
+            .invalidAPIKey,
+            .networkError(NSError(domain: "test", code: 0)),
+            .serverError(500, "test"),
+            .decodingError("test"),
+            .invalidRequest
+        ]
+
+        for error in errors {
+            // All errors should have a non-nil errorDescription
+            XCTAssertNotNil(error.errorDescription, "Error \(error) should have errorDescription")
+        }
+    }
+}
+
+final class ConfigurationTests: XCTestCase {
+
+    func testConfigureWithAppId() {
+        let cutiE = CutiE.shared
+
+        cutiE.configure(appId: "app_test123")
+
+        XCTAssertTrue(cutiE.isConfigured)
+        XCTAssertNotNil(cutiE.configuration)
+        XCTAssertEqual(cutiE.configuration?.appId, "app_test123")
+        XCTAssertEqual(cutiE.configuration?.apiURL, "https://api.cuti-e.com")
+        XCTAssertFalse(cutiE.configuration?.useAppAttest ?? true)
+    }
+
+    func testConfigureWithCustomApiURL() {
+        let cutiE = CutiE.shared
+
+        cutiE.configure(appId: "app_test", apiURL: "https://custom.api.com")
+
+        XCTAssertEqual(cutiE.configuration?.apiURL, "https://custom.api.com")
+    }
+
+    func testConfigureWithAppAttest() {
+        let cutiE = CutiE.shared
+
+        cutiE.configure(appId: "app_test", useAppAttest: true)
+
+        XCTAssertTrue(cutiE.configuration?.useAppAttest ?? false)
+    }
+
+    func testDeviceIDPersistence() {
+        let cutiE = CutiE.shared
+
+        cutiE.configure(appId: "app_test1")
+        let deviceID1 = cutiE.configuration?.deviceID
+
+        cutiE.configure(appId: "app_test2")
+        let deviceID2 = cutiE.configuration?.deviceID
+
+        XCTAssertNotNil(deviceID1)
+        XCTAssertEqual(deviceID1, deviceID2, "Device ID should persist across configurations")
+        XCTAssertTrue(deviceID1?.hasPrefix("device_") ?? false)
+    }
+
+    func testSetUserID() {
+        let cutiE = CutiE.shared
+        cutiE.configure(appId: "app_test")
+
+        cutiE.setUserID("user_123")
+        XCTAssertEqual(cutiE.configuration?.userID, "user_123")
+
+        cutiE.setUserID(nil)
+        XCTAssertNil(cutiE.configuration?.userID)
+    }
+
+    func testSetUserId() {
+        let cutiE = CutiE.shared
+        cutiE.configure(appId: "app_test")
+
+        // Test alias method
+        cutiE.setUserId("user_456")
+        XCTAssertEqual(cutiE.configuration?.userID, "user_456")
+    }
+
+    func testSetUserName() {
+        let cutiE = CutiE.shared
+        cutiE.configure(appId: "app_test")
+
+        cutiE.setUserName("John Doe")
+        XCTAssertEqual(cutiE.configuration?.userName, "John Doe")
+
+        cutiE.setUserName(nil)
+        XCTAssertNil(cutiE.configuration?.userName)
+    }
+
+    func testSetAppMetadata() {
+        let cutiE = CutiE.shared
+        cutiE.configure(appId: "app_test")
+
+        cutiE.setAppMetadata(version: "1.2.3", build: "100")
+
+        XCTAssertEqual(cutiE.configuration?.appVersion, "1.2.3")
+        XCTAssertEqual(cutiE.configuration?.appBuild, "100")
+    }
+
+    func testIsConfiguredFalseBeforeConfiguration() {
+        // Create a new reference and clear existing config
+        let cutiE = CutiE.shared
+        cutiE.configuration = nil
+        cutiE.apiClient = nil
+
+        XCTAssertFalse(cutiE.isConfigured)
+    }
+
+    func testCutiEConfigurationClass() {
+        let config = CutiEConfiguration(
+            apiKey: nil,
+            apiURL: "https://api.test.com",
+            deviceID: "device_test",
+            appId: "app_test",
+            useAppAttest: true
+        )
+
+        XCTAssertNil(config.apiKey)
+        XCTAssertEqual(config.apiURL, "https://api.test.com")
+        XCTAssertEqual(config.deviceID, "device_test")
+        XCTAssertEqual(config.appId, "app_test")
+        XCTAssertTrue(config.useAppAttest)
+    }
+
+    func testCutiEConfigurationWithApiKey() {
+        let config = CutiEConfiguration(
+            apiKey: "key_legacy",
+            apiURL: "https://api.test.com",
+            deviceID: "device_test",
+            appId: "app_test",
+            useAppAttest: false
+        )
+
+        XCTAssertEqual(config.apiKey, "key_legacy")
+        XCTAssertFalse(config.useAppAttest)
+    }
+}

--- a/Tests/CutiETests/JSONDecodingTests.swift
+++ b/Tests/CutiETests/JSONDecodingTests.swift
@@ -1,0 +1,334 @@
+import XCTest
+@testable import CutiE
+
+final class JSONDecodingTests: XCTestCase {
+
+    // MARK: - Conversation JSON Decoding
+
+    func testConversationDecoding() throws {
+        let json = """
+        {
+            "conversation_id": "conv_abc123",
+            "customer_id": "cust_456",
+            "user_id": "user_789",
+            "user_name": "John Doe",
+            "device_id": "device_xyz",
+            "title": "Bug in login",
+            "category": "bug",
+            "status": "open",
+            "priority": "high",
+            "assigned_admin_id": "admin_1",
+            "app_id": "app_test",
+            "message_count": 5,
+            "unread_count": 2,
+            "created_at": 1700000000000,
+            "updated_at": 1700000100000
+        }
+        """.data(using: .utf8)!
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: json)
+
+        XCTAssertEqual(conversation.id, "conv_abc123")
+        XCTAssertEqual(conversation.customerID, "cust_456")
+        XCTAssertEqual(conversation.userID, "user_789")
+        XCTAssertEqual(conversation.userName, "John Doe")
+        XCTAssertEqual(conversation.deviceID, "device_xyz")
+        XCTAssertEqual(conversation.title, "Bug in login")
+        XCTAssertEqual(conversation.category, .bug)
+        XCTAssertEqual(conversation.status, .open)
+        XCTAssertEqual(conversation.priority, .high)
+        XCTAssertEqual(conversation.assignedAdminID, "admin_1")
+        XCTAssertEqual(conversation.appId, "app_test")
+        XCTAssertEqual(conversation.messageCount, 5)
+        XCTAssertEqual(conversation.unreadCount, 2)
+    }
+
+    func testConversationDecodingAllStatuses() throws {
+        let statuses = ["open", "in_progress", "waiting_user", "waiting_admin", "resolved", "closed"]
+        let expected: [ConversationStatus] = [.open, .in_progress, .waiting_user, .waiting_admin, .resolved, .closed]
+
+        for (status, expectedStatus) in zip(statuses, expected) {
+            let json = """
+            {
+                "conversation_id": "conv_1",
+                "status": "\(status)",
+                "created_at": 1700000000000
+            }
+            """.data(using: .utf8)!
+
+            let conversation = try JSONDecoder().decode(Conversation.self, from: json)
+            XCTAssertEqual(conversation.status, expectedStatus, "Status '\(status)' should decode to \(expectedStatus)")
+        }
+    }
+
+    func testConversationDecodingAllCategories() throws {
+        let categories = ["bug", "feature", "question", "feedback", "other"]
+        let expected: [ConversationCategory] = [.bug, .feature, .question, .feedback, .other]
+
+        for (category, expectedCategory) in zip(categories, expected) {
+            let json = """
+            {
+                "conversation_id": "conv_1",
+                "category": "\(category)",
+                "status": "open",
+                "created_at": 1700000000000
+            }
+            """.data(using: .utf8)!
+
+            let conversation = try JSONDecoder().decode(Conversation.self, from: json)
+            XCTAssertEqual(conversation.category, expectedCategory, "Category '\(category)' should decode to \(expectedCategory)")
+        }
+    }
+
+    func testConversationDecodingAllPriorities() throws {
+        let priorities = ["low", "normal", "high", "urgent"]
+        let expected: [ConversationPriority] = [.low, .normal, .high, .urgent]
+
+        for (priority, expectedPriority) in zip(priorities, expected) {
+            let json = """
+            {
+                "conversation_id": "conv_1",
+                "priority": "\(priority)",
+                "status": "open",
+                "created_at": 1700000000000
+            }
+            """.data(using: .utf8)!
+
+            let conversation = try JSONDecoder().decode(Conversation.self, from: json)
+            XCTAssertEqual(conversation.priority, expectedPriority, "Priority '\(priority)' should decode to \(expectedPriority)")
+        }
+    }
+
+    func testConversationDecodingWithMessages() throws {
+        let json = """
+        {
+            "conversation_id": "conv_1",
+            "status": "open",
+            "created_at": 1700000000000,
+            "messages": [
+                {
+                    "message_id": "msg_1",
+                    "conversation_id": "conv_1",
+                    "sender_type": "user",
+                    "message": "Hello",
+                    "message_type": "text",
+                    "is_internal_note": false,
+                    "created_at": 1700000000000
+                },
+                {
+                    "message_id": "msg_2",
+                    "conversation_id": "conv_1",
+                    "sender_type": "admin",
+                    "message": "Hi there!",
+                    "message_type": "text",
+                    "is_internal_note": false,
+                    "created_at": 1700000050000
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: json)
+
+        XCTAssertNotNil(conversation.messages)
+        XCTAssertEqual(conversation.messages?.count, 2)
+        XCTAssertEqual(conversation.messages?[0].message, "Hello")
+        XCTAssertEqual(conversation.messages?[1].message, "Hi there!")
+    }
+
+    func testConversationDecodingWithTags() throws {
+        let json = """
+        {
+            "conversation_id": "conv_1",
+            "status": "open",
+            "created_at": 1700000000000,
+            "tags": [
+                {
+                    "tag_id": "tag_1",
+                    "conversation_id": "conv_1",
+                    "tag_name": "urgent",
+                    "tag_color": "#FF0000"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: json)
+
+        XCTAssertNotNil(conversation.tags)
+        XCTAssertEqual(conversation.tags?.count, 1)
+        XCTAssertEqual(conversation.tags?[0].tagName, "urgent")
+    }
+
+    func testConversationDecodingMinimalFields() throws {
+        let json = """
+        {
+            "conversation_id": "conv_minimal",
+            "status": "open",
+            "created_at": 1700000000000
+        }
+        """.data(using: .utf8)!
+
+        let conversation = try JSONDecoder().decode(Conversation.self, from: json)
+
+        XCTAssertEqual(conversation.id, "conv_minimal")
+        XCTAssertEqual(conversation.status, .open)
+        XCTAssertNil(conversation.customerID)
+        XCTAssertNil(conversation.userID)
+        XCTAssertNil(conversation.userName)
+        XCTAssertNil(conversation.deviceID)
+        XCTAssertNil(conversation.title)
+        XCTAssertNil(conversation.category)
+        XCTAssertNil(conversation.priority)
+        XCTAssertNil(conversation.assignedAdminID)
+        XCTAssertNil(conversation.appId)
+        XCTAssertNil(conversation.messageCount)
+        XCTAssertNil(conversation.unreadCount)
+        XCTAssertNil(conversation.messages)
+        XCTAssertNil(conversation.tags)
+        XCTAssertNil(conversation.updatedAt)
+    }
+
+    // MARK: - Message JSON Decoding
+
+    func testMessageDecoding() throws {
+        let json = """
+        {
+            "message_id": "msg_abc",
+            "conversation_id": "conv_123",
+            "sender_type": "user",
+            "sender_id": "user_xyz",
+            "sender_name": "John",
+            "sender_avatar_url": "https://example.com/avatar.png",
+            "message": "This is my feedback",
+            "message_type": "text",
+            "is_internal_note": false,
+            "created_at": 1700000000000
+        }
+        """.data(using: .utf8)!
+
+        let message = try JSONDecoder().decode(Message.self, from: json)
+
+        XCTAssertEqual(message.id, "msg_abc")
+        XCTAssertEqual(message.conversationID, "conv_123")
+        XCTAssertEqual(message.senderType, .user)
+        XCTAssertEqual(message.senderID, "user_xyz")
+        XCTAssertEqual(message.senderName, "John")
+        XCTAssertEqual(message.senderAvatarUrl, "https://example.com/avatar.png")
+        XCTAssertEqual(message.message, "This is my feedback")
+        XCTAssertEqual(message.messageType, "text")
+        XCTAssertFalse(message.isInternalNote)
+    }
+
+    func testMessageDecodingInternalNote() throws {
+        let json = """
+        {
+            "message_id": "msg_internal",
+            "conversation_id": "conv_123",
+            "sender_type": "admin",
+            "message": "Internal note for team",
+            "message_type": "text",
+            "is_internal_note": true,
+            "created_at": 1700000000000
+        }
+        """.data(using: .utf8)!
+
+        let message = try JSONDecoder().decode(Message.self, from: json)
+
+        XCTAssertTrue(message.isInternalNote)
+        XCTAssertEqual(message.senderType, .admin)
+    }
+
+    func testMessageDecodingSystemMessage() throws {
+        let json = """
+        {
+            "message_id": "msg_system",
+            "conversation_id": "conv_123",
+            "sender_type": "system",
+            "message": "Status changed to resolved",
+            "message_type": "text",
+            "is_internal_note": false,
+            "created_at": 1700000000000
+        }
+        """.data(using: .utf8)!
+
+        let message = try JSONDecoder().decode(Message.self, from: json)
+
+        XCTAssertEqual(message.senderType, .system)
+    }
+
+    // MARK: - CreateConversationResponse Tests
+
+    func testCreateConversationResponseDecoding() throws {
+        let json = """
+        {
+            "conversation_id": "conv_new",
+            "status": "open",
+            "message_id": "msg_initial",
+            "created_at": 1700000000000
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CreateConversationResponse.self, from: json)
+
+        XCTAssertEqual(response.conversationId, "conv_new")
+        XCTAssertEqual(response.status, "open")
+        XCTAssertEqual(response.messageId, "msg_initial")
+        XCTAssertEqual(response.createdAt, 1700000000000)
+    }
+
+    func testCreateConversationResponseStatusConversion() throws {
+        let json = """
+        {
+            "conversation_id": "conv_1",
+            "status": "in_progress"
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CreateConversationResponse.self, from: json)
+
+        XCTAssertEqual(response.conversationStatus, .in_progress)
+    }
+
+    func testCreateConversationResponseDefaultStatus() throws {
+        let json = """
+        {
+            "conversation_id": "conv_1"
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CreateConversationResponse.self, from: json)
+
+        // When status is nil, should default to .open
+        XCTAssertEqual(response.conversationStatus, .open)
+    }
+
+    func testCreateConversationResponseInvalidStatus() throws {
+        let json = """
+        {
+            "conversation_id": "conv_1",
+            "status": "invalid_status"
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CreateConversationResponse.self, from: json)
+
+        // When status is invalid, should default to .open
+        XCTAssertEqual(response.conversationStatus, .open)
+    }
+
+    func testCreateConversationResponseCreatedAtFallback() throws {
+        let json = """
+        {
+            "conversation_id": "conv_1"
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CreateConversationResponse.self, from: json)
+
+        // When createdAt is nil, should return current timestamp
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        // Allow 1 second tolerance
+        XCTAssertTrue(abs(response.createdAtInt64 - now) < 1000, "Created at should be close to current time")
+    }
+}

--- a/Tests/CutiETests/ModelTests.swift
+++ b/Tests/CutiETests/ModelTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+@testable import CutiE
+
+final class ModelTests: XCTestCase {
+
+    // MARK: - Conversation Tests
+
+    func testConversationCreation() {
+        let conversation = Conversation(
+            id: "conv_123",
+            customerID: "cust_456",
+            userID: "user_789",
+            userName: "John Doe",
+            deviceID: "device_abc",
+            title: "Test Issue",
+            category: .bug,
+            status: .open,
+            priority: .high,
+            appId: "app_test",
+            messageCount: 5,
+            unreadCount: 2,
+            createdAt: 1700000000000,
+            updatedAt: 1700000100000
+        )
+
+        XCTAssertEqual(conversation.id, "conv_123")
+        XCTAssertEqual(conversation.customerID, "cust_456")
+        XCTAssertEqual(conversation.userID, "user_789")
+        XCTAssertEqual(conversation.userName, "John Doe")
+        XCTAssertEqual(conversation.deviceID, "device_abc")
+        XCTAssertEqual(conversation.title, "Test Issue")
+        XCTAssertEqual(conversation.category, .bug)
+        XCTAssertEqual(conversation.status, .open)
+        XCTAssertEqual(conversation.priority, .high)
+        XCTAssertEqual(conversation.appId, "app_test")
+        XCTAssertEqual(conversation.messageCount, 5)
+        XCTAssertEqual(conversation.unreadCount, 2)
+    }
+
+    func testConversationHasUnread() {
+        let withUnread = Conversation(
+            id: "1",
+            status: .open,
+            unreadCount: 3,
+            createdAt: 1700000000000
+        )
+        XCTAssertTrue(withUnread.hasUnread)
+
+        let withoutUnread = Conversation(
+            id: "2",
+            status: .open,
+            unreadCount: 0,
+            createdAt: 1700000000000
+        )
+        XCTAssertFalse(withoutUnread.hasUnread)
+
+        let nilUnread = Conversation(
+            id: "3",
+            status: .open,
+            createdAt: 1700000000000
+        )
+        XCTAssertFalse(nilUnread.hasUnread)
+    }
+
+    func testConversationDateConversions() {
+        // Test timestamp: 1700000000000 ms = November 14, 2023 22:13:20 UTC
+        let conversation = Conversation(
+            id: "1",
+            status: .open,
+            createdAt: 1700000000000,
+            updatedAt: 1700000100000
+        )
+
+        let expectedCreatedDate = Date(timeIntervalSince1970: 1700000000)
+        let expectedUpdatedDate = Date(timeIntervalSince1970: 1700000100)
+
+        XCTAssertEqual(conversation.createdDate, expectedCreatedDate)
+        XCTAssertEqual(conversation.updatedDate, expectedUpdatedDate)
+    }
+
+    func testConversationUpdatedDateFallback() {
+        let conversation = Conversation(
+            id: "1",
+            status: .open,
+            createdAt: 1700000000000,
+            updatedAt: nil
+        )
+
+        // When updatedAt is nil, should fall back to createdAt
+        let expectedDate = Date(timeIntervalSince1970: 1700000000)
+        XCTAssertEqual(conversation.updatedDate, expectedDate)
+    }
+
+    // MARK: - Message Tests
+
+    func testMessageCreation() {
+        let message = Message(
+            id: "msg_123",
+            conversationID: "conv_456",
+            senderType: .user,
+            senderID: "user_789",
+            senderName: "John",
+            senderAvatarUrl: "https://example.com/avatar.png",
+            message: "Hello, this is my feedback",
+            messageType: "text",
+            isInternalNote: false,
+            createdAt: 1700000000000
+        )
+
+        XCTAssertEqual(message.id, "msg_123")
+        XCTAssertEqual(message.conversationID, "conv_456")
+        XCTAssertEqual(message.senderType, .user)
+        XCTAssertEqual(message.senderID, "user_789")
+        XCTAssertEqual(message.senderName, "John")
+        XCTAssertEqual(message.senderAvatarUrl, "https://example.com/avatar.png")
+        XCTAssertEqual(message.message, "Hello, this is my feedback")
+        XCTAssertEqual(message.messageType, "text")
+        XCTAssertFalse(message.isInternalNote)
+    }
+
+    func testMessageDateConversion() {
+        let message = Message(
+            id: "1",
+            conversationID: "conv_1",
+            senderType: .admin,
+            message: "Response",
+            createdAt: 1700000000000
+        )
+
+        let expectedDate = Date(timeIntervalSince1970: 1700000000)
+        XCTAssertEqual(message.createdDate, expectedDate)
+    }
+
+    func testMessageSenderTypes() {
+        let userMessage = Message(
+            id: "1",
+            conversationID: "conv_1",
+            senderType: .user,
+            message: "User msg",
+            createdAt: 1700000000000
+        )
+        XCTAssertEqual(userMessage.senderType, .user)
+
+        let adminMessage = Message(
+            id: "2",
+            conversationID: "conv_1",
+            senderType: .admin,
+            message: "Admin msg",
+            createdAt: 1700000000000
+        )
+        XCTAssertEqual(adminMessage.senderType, .admin)
+
+        let systemMessage = Message(
+            id: "3",
+            conversationID: "conv_1",
+            senderType: .system,
+            message: "System msg",
+            createdAt: 1700000000000
+        )
+        XCTAssertEqual(systemMessage.senderType, .system)
+    }
+
+    // MARK: - SenderType Tests
+
+    func testSenderTypeRawValues() {
+        XCTAssertEqual(SenderType.user.rawValue, "user")
+        XCTAssertEqual(SenderType.admin.rawValue, "admin")
+        XCTAssertEqual(SenderType.system.rawValue, "system")
+    }
+
+    // MARK: - ConversationCategory Tests
+
+    func testConversationCategoryColors() {
+        XCTAssertEqual(ConversationCategory.bug.color, "red")
+        XCTAssertEqual(ConversationCategory.feature.color, "purple")
+        XCTAssertEqual(ConversationCategory.question.color, "blue")
+        XCTAssertEqual(ConversationCategory.feedback.color, "green")
+        XCTAssertEqual(ConversationCategory.other.color, "gray")
+    }
+
+    func testConversationCategoryCaseIterable() {
+        let allCases = ConversationCategory.allCases
+        XCTAssertEqual(allCases.count, 5)
+        XCTAssertTrue(allCases.contains(.bug))
+        XCTAssertTrue(allCases.contains(.feature))
+        XCTAssertTrue(allCases.contains(.question))
+        XCTAssertTrue(allCases.contains(.feedback))
+        XCTAssertTrue(allCases.contains(.other))
+    }
+
+    func testConversationCategoryRawValues() {
+        XCTAssertEqual(ConversationCategory.bug.rawValue, "bug")
+        XCTAssertEqual(ConversationCategory.feature.rawValue, "feature")
+        XCTAssertEqual(ConversationCategory.question.rawValue, "question")
+        XCTAssertEqual(ConversationCategory.feedback.rawValue, "feedback")
+        XCTAssertEqual(ConversationCategory.other.rawValue, "other")
+    }
+
+    // MARK: - ConversationStatus Tests
+
+    func testConversationStatusColors() {
+        XCTAssertEqual(ConversationStatus.open.color, "blue")
+        XCTAssertEqual(ConversationStatus.in_progress.color, "orange")
+        XCTAssertEqual(ConversationStatus.waiting_user.color, "yellow")
+        XCTAssertEqual(ConversationStatus.waiting_admin.color, "red")
+        XCTAssertEqual(ConversationStatus.resolved.color, "green")
+        XCTAssertEqual(ConversationStatus.closed.color, "gray")
+    }
+
+    func testConversationStatusCaseIterable() {
+        let allCases = ConversationStatus.allCases
+        XCTAssertEqual(allCases.count, 6)
+        XCTAssertTrue(allCases.contains(.open))
+        XCTAssertTrue(allCases.contains(.in_progress))
+        XCTAssertTrue(allCases.contains(.waiting_user))
+        XCTAssertTrue(allCases.contains(.waiting_admin))
+        XCTAssertTrue(allCases.contains(.resolved))
+        XCTAssertTrue(allCases.contains(.closed))
+    }
+
+    func testConversationStatusRawValues() {
+        XCTAssertEqual(ConversationStatus.open.rawValue, "open")
+        XCTAssertEqual(ConversationStatus.in_progress.rawValue, "in_progress")
+        XCTAssertEqual(ConversationStatus.waiting_user.rawValue, "waiting_user")
+        XCTAssertEqual(ConversationStatus.waiting_admin.rawValue, "waiting_admin")
+        XCTAssertEqual(ConversationStatus.resolved.rawValue, "resolved")
+        XCTAssertEqual(ConversationStatus.closed.rawValue, "closed")
+    }
+
+    // MARK: - ConversationPriority Tests
+
+    func testConversationPriorityColors() {
+        XCTAssertEqual(ConversationPriority.low.color, "gray")
+        XCTAssertEqual(ConversationPriority.normal.color, "blue")
+        XCTAssertEqual(ConversationPriority.high.color, "orange")
+        XCTAssertEqual(ConversationPriority.urgent.color, "red")
+    }
+
+    func testConversationPriorityCaseIterable() {
+        let allCases = ConversationPriority.allCases
+        XCTAssertEqual(allCases.count, 4)
+        XCTAssertTrue(allCases.contains(.low))
+        XCTAssertTrue(allCases.contains(.normal))
+        XCTAssertTrue(allCases.contains(.high))
+        XCTAssertTrue(allCases.contains(.urgent))
+    }
+
+    func testConversationPriorityRawValues() {
+        XCTAssertEqual(ConversationPriority.low.rawValue, "low")
+        XCTAssertEqual(ConversationPriority.normal.rawValue, "normal")
+        XCTAssertEqual(ConversationPriority.high.rawValue, "high")
+        XCTAssertEqual(ConversationPriority.urgent.rawValue, "urgent")
+    }
+
+    // MARK: - Tag Tests
+
+    func testTagDecoding() throws {
+        let json = """
+        {
+            "tag_id": "tag_123",
+            "conversation_id": "conv_456",
+            "tag_name": "important",
+            "tag_color": "#FF0000"
+        }
+        """.data(using: .utf8)!
+
+        let tag = try JSONDecoder().decode(Tag.self, from: json)
+
+        XCTAssertEqual(tag.id, "tag_123")
+        XCTAssertEqual(tag.conversationID, "conv_456")
+        XCTAssertEqual(tag.tagName, "important")
+        XCTAssertEqual(tag.tagColor, "#FF0000")
+    }
+
+    func testTagDecodingWithNilColor() throws {
+        let json = """
+        {
+            "tag_id": "tag_123",
+            "conversation_id": "conv_456",
+            "tag_name": "important",
+            "tag_color": null
+        }
+        """.data(using: .utf8)!
+
+        let tag = try JSONDecoder().decode(Tag.self, from: json)
+
+        XCTAssertEqual(tag.id, "tag_123")
+        XCTAssertNil(tag.tagColor)
+    }
+}


### PR DESCRIPTION
## Summary

- Add App Attest (DCAppAttestService) support for cryptographic device verification
- Add new API client methods for attestation flow
- Add comprehensive test coverage for device linking, JSON decoding, errors, and models

### App Attest Features

The SDK now supports Apple's App Attest for enhanced security:

- `CutiEAppAttest.shared` - Manage device attestation
- `performAttestation()` - Complete attestation flow with Apple
- `generateAssertion(for:)` - Sign requests with device credentials
- Automatic key storage in Keychain

### Backend Endpoints

- `POST /v1/device/attest/challenge` - Get attestation challenge
- `POST /v1/device/attest` - Submit attestation
- `POST /v1/device/attest/assert` - Verify assertion
- `GET /v1/device/attest/status` - Check attestation status
- `DELETE /v1/device/attest` - Revoke attestation

### Test Coverage

New tests added:
- DeviceLinkingTests
- ErrorTests
- JSONDecodingTests
- ModelTests

🤖 Generated with [Claude Code](https://claude.com/claude-code)