### PR TITLE
ci: Add auto-merge workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,89 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - name: Get PR number
+        id: get-pr
+        run: echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
+      - name: Wait for CI checks
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('Waiting for CI checks to complete...');
+
+            const pr_number = ${{ steps.get-pr.outputs.pr_number }};
+            const maxWait = 15 * 60 * 1000; // 15 minutes
+            const startTime = Date.now();
+            const checkInterval = 15000; // Check every 15 seconds
+
+            while (Date.now() - startTime < maxWait) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr_number
+              });
+
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha
+              });
+
+              // Exclude this workflow from checks
+              const currentRunId = process.env.GITHUB_RUN_ID;
+              const otherChecks = checks.check_runs.filter(check => {
+                return !check.details_url?.includes(`/runs/${currentRunId}`);
+              });
+
+              if (otherChecks.length === 0) {
+                console.log('No other checks found, waiting...');
+                await new Promise(resolve => setTimeout(resolve, checkInterval));
+                continue;
+              }
+
+              const allComplete = otherChecks.every(check => check.status === 'completed');
+
+              if (allComplete) {
+                const allPassed = otherChecks.every(check =>
+                  check.conclusion === 'success' || check.conclusion === 'skipped'
+                );
+
+                if (allPassed) {
+                  console.log('All checks passed!');
+                  return;
+                } else {
+                  const failed = otherChecks.filter(c => c.conclusion !== 'success' && c.conclusion !== 'skipped');
+                  console.log('Some checks failed:', failed.map(c => `${c.name}: ${c.conclusion}`));
+                  core.setFailed('CI checks failed');
+                  return;
+                }
+              }
+
+              const running = otherChecks.filter(c => c.status !== 'completed');
+              console.log(`Waiting for ${running.length} check(s): ${running.map(c => c.name).join(', ')}`);
+              await new Promise(resolve => setTimeout(resolve, checkInterval));
+            }
+
+            core.setFailed('Timeout waiting for checks');
+
+      - name: Enable auto-merge
+        if: success()
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.get-pr.outputs.pr_number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to auto-merge Dependabot PRs
- Only triggers for `dependabot[bot]` actor
- Waits for all CI checks to pass before enabling auto-merge
- Uses squash merge method

## Requirements
**Note:** "Allow auto-merge" must be enabled in repo settings for this to work:
Settings > General > Pull Requests > Allow auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)