### PR TITLE
fix: Replace print() with NSLog for consistent logging

### DIFF
--- a/Sources/CutiE/CutiESubscriptionManager.swift
+++ b/Sources/CutiE/CutiESubscriptionManager.swift
@@ -226,7 +226,7 @@ public class CutiESubscriptionManager: ObservableObject {
             )
         } catch {
             // Log error but don't fail - subscription still valid locally
-            print("[CutiE] Failed to sync subscription with backend: \(error)")
+            NSLog("[CutiE] Failed to sync subscription with backend: %@", error as NSError)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaced `print()` with `NSLog()` in `CutiESubscriptionManager.swift` for consistent logging
- Ensures error messages appear in device logs for production debugging

Fixes #27

## Test plan
- [x] Build succeeds
- [ ] Verify logs appear in Console.app when running on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)