### PR TITLE
fix(ci): Use generic simulator destination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           xcodebuild build \
             -scheme CutiE \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+            -destination 'generic/platform=iOS Simulator' \
             -skipPackagePluginValidation
 
       - name: Build for macOS
@@ -53,7 +53,7 @@ jobs:
         run: |
           xcodebuild docbuild \
             -scheme CutiE \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+            -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath .build
 
       # Note: Upload disabled - DocC generates filenames with colons (Swift function signatures)


### PR DESCRIPTION
## Summary
Use `generic/platform=iOS Simulator` instead of specific device name (`iPhone 16 Pro`) to avoid CI failures when Xcode updates change available simulators.

The self-hosted runner was updated to Xcode 17 beta which has iPhone 17 simulators but not iPhone 16 Pro.

## Test plan
- [ ] CI build passes with generic destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)