### PR TITLE
fix: Add HTTPS enforcement in configure()

### DIFF
--- a/Sources/CutiE/CutiE.swift
+++ b/Sources/CutiE/CutiE.swift
@@ -57,6 +57,12 @@ public class CutiE {
     ///   - apiURL: Optional custom API URL (defaults to production)
     ///   - useAppAttest: Enable Apple App Attest for enhanced security (iOS 14+). When enabled, requests are cryptographically signed by the Secure Enclave. Automatically falls back on unsupported devices.
     public func configure(appId: String, apiURL: String = "https://api.cuti-e.com", useAppAttest: Bool = false) {
+        // Enforce HTTPS for security and validate URL format
+        guard let url = URL(string: apiURL), url.scheme?.lowercased() == "https" else {
+            NSLog("[CutiE] ERROR: apiURL must be a valid HTTPS URL. Configuration rejected.")
+            return
+        }
+
         self.configuration = CutiEConfiguration(
             apiKey: nil,
             apiURL: apiURL,


### PR DESCRIPTION
## Summary
- Reject configuration if `apiURL` doesn't use HTTPS
- Prevents accidental HTTP usage in production

Fixes #25

## Test plan
- [x] Build succeeds
- [ ] `configure(appId: "x", apiURL: "http://...")` logs error and doesn't configure

🤖 Generated with [Claude Code](https://claude.com/claude-code)