### PR TITLE
docs: Add comprehensive DocC documentation for public APIs

### DIFF
--- a/Sources/CutiE/CutiE.docc/CutiE.md
+++ b/Sources/CutiE/CutiE.docc/CutiE.md
@@ -1,0 +1,75 @@
+# ``CutiE``
+
+The official iOS SDK for integrating Cuti-E feedback and support into your app.
+
+## Overview
+
+CutiE SDK provides a complete solution for collecting user feedback, managing support conversations, and handling in-app subscriptions. The SDK offers both completion handler and async/await APIs for flexibility.
+
+### Getting Started
+
+Configure the SDK in your app's launch sequence:
+
+```swift
+import CutiE
+
+// In your App or AppDelegate
+CutiE.shared.configure(appId: "your_app_id")
+```
+
+### Creating Feedback
+
+Users can submit feedback through conversations:
+
+```swift
+CutiE.shared.createConversation(
+    category: .feedback,
+    message: "Great app!"
+) { result in
+    switch result {
+    case .success(let conversationId):
+        print("Created conversation: \(conversationId)")
+    case .failure(let error):
+        print("Error: \(error)")
+    }
+}
+```
+
+### Displaying the Inbox
+
+Show the built-in inbox UI for users to view their conversations:
+
+```swift
+if #available(iOS 15.0, *) {
+    CutiE.shared.showInbox()
+}
+```
+
+## Topics
+
+### Essentials
+
+- ``CutiE``
+- ``CutiEConfiguration``
+- ``CutiEError``
+
+### Conversations
+
+- ``Conversation``
+- ``ConversationCategory``
+- ``Message``
+
+### Subscriptions
+
+- ``CutiESubscriptionManager``
+- ``SubscriptionTier``
+- ``SubscriptionStatus``
+
+### Security
+
+- ``CutiEAppAttest``
+- ``AppAttestError``
+
+### Push Notifications
+
+- ``CutiEPushNotifications``

--- a/Sources/CutiE/CutiE.docc/GettingStarted.md
+++ b/Sources/CutiE/CutiE.docc/GettingStarted.md
@@ -1,0 +1,77 @@
+# Getting Started with CutiE
+
+Learn how to integrate CutiE SDK into your iOS app.
+
+## Overview
+
+This guide walks you through the basic setup and configuration of the CutiE SDK.
+
+### Requirements
+
+- iOS 14.0+ (iOS 15.0+ for async/await APIs and Inbox UI)
+- Xcode 14.0+
+- Swift 5.7+
+
+### Installation
+
+Add CutiE to your project using Swift Package Manager:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/cuti-e/ios-sdk.git", from: "1.0.0")
+]
+```
+
+### Configuration
+
+Configure the SDK early in your app's lifecycle, typically in your `App` struct or `AppDelegate`:
+
+```swift
+import SwiftUI
+import CutiE
+
+@main
+struct MyApp: App {
+    init() {
+        // Configure with your App ID from the Cuti-E dashboard
+        CutiE.shared.configure(appId: "app_your_app_id")
+
+        // Optionally set user information
+        CutiE.shared.setUserId("user_123")
+        CutiE.shared.setUserName("John D.")
+
+        // Set app metadata for better context
+        CutiE.shared.setAppMetadata(
+            version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+            build: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        )
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+### Enhanced Security with App Attest
+
+For enhanced security, enable Apple App Attest to cryptographically verify requests:
+
+```swift
+CutiE.shared.configure(
+    appId: "app_your_app_id",
+    useAppAttest: true
+)
+```
+
+> Note: App Attest requires iOS 14+ and is not available on simulators.
+
+## Topics
+
+### Next Steps
+
+- <doc:CreatingConversations>
+- <doc:ManagingSubscriptions>
+- <doc:PushNotifications>


### PR DESCRIPTION
## Summary
- Add DocC documentation catalog with overview and getting started guide
- Document all public APIs in CutiEAppAttest and CutiESubscriptionManager
- Include code examples throughout documentation

## Files Changed
- `Sources/CutiE/CutiE.docc/CutiE.md` - Main documentation overview
- `Sources/CutiE/CutiE.docc/GettingStarted.md` - Getting started guide
- `Sources/CutiE/CutiEAppAttest.swift` - Documentation for App Attest APIs
- `Sources/CutiE/CutiESubscriptionManager.swift` - Documentation for subscription APIs

## Documentation Coverage
- **CutiEAppAttest**: `isSupported`, `isAttested`, `generateAssertion(for:)`, `reset()`
- **CutiESubscriptionManager**: `currentTier`, `subscriptionStatus`, `products`, `isLoading`, `loadProducts()`, `purchase(_:)`, `restorePurchases()`, `updateSubscriptionStatus()`
- **Enums**: `SubscriptionTier`, `SubscriptionStatus`

Fixes #23

## Test Plan
- [x] Documentation builds successfully (`xcodebuild docbuild`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)