### PR TITLE
docs: Link ARCHITECTURE.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Character-driven feedback platform for iOS apps. Make customer support delightfu
 - 🔐 **App Attest** - Enhanced device verification using Apple's secure enclave (iOS 14+)
 - 📲 **Device Linking** - Share conversation inbox across multiple devices via QR code
 
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for C4 diagrams showing the SDK structure, component relationships, and data flows.
+
 ## Installation
 
 ### Swift Package Manager


### PR DESCRIPTION
## Summary

Add Architecture section to README with link to the C4 diagrams documentation.

## Test plan

- [ ] Verify link works on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)