### PR TITLE
feat: Add certificate pinning expiry monitoring

### DIFF
--- a/.github/workflows/pin-expiry-check.yml
+++ b/.github/workflows/pin-expiry-check.yml
@@ -1,0 +1,93 @@
+name: Certificate Pin Expiry Check
+
+on:
+  schedule:
+    # Run monthly on the 1st at 00:00 UTC
+    - cron: '0 0 1 * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-expiry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check certificate pin expiry
+        id: expiry-check
+        run: |
+          # Certificate pins expire June 22, 2036
+          EXPIRY_DATE="2036-06-22"
+          EXPIRY_EPOCH=$(date -d "$EXPIRY_DATE" +%s)
+          NOW_EPOCH=$(date +%s)
+          DAYS_UNTIL=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
+
+          echo "days_until=$DAYS_UNTIL" >> $GITHUB_OUTPUT
+
+          if [ $DAYS_UNTIL -lt 0 ]; then
+            echo "::error::Certificate pins have EXPIRED! Immediate action required."
+            exit 1
+          elif [ $DAYS_UNTIL -lt 365 ]; then
+            echo "::warning::Certificate pins expire in $DAYS_UNTIL days. Plan SDK update."
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          else
+            echo "Certificate pins valid for $DAYS_UNTIL more days (expires $EXPIRY_DATE)"
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create issue if expiring within 1 year
+        if: steps.expiry-check.outputs.needs_update == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const daysUntil = ${{ steps.expiry-check.outputs.days_until }};
+            const title = `Certificate pins expiring in ${daysUntil} days`;
+
+            // Check if issue already exists
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security,certificate-pinning'
+            });
+
+            const existingIssue = issues.data.find(i => i.title.includes('Certificate pins expiring'));
+
+            if (existingIssue) {
+              console.log(`Issue already exists: #${existingIssue.number}`);
+              // Update the existing issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: `Monthly check: Certificate pins expire in **${daysUntil} days** (June 22, 2036).`
+              });
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: `## Certificate Pin Expiry Warning
+
+The SSL certificate pins in this SDK will expire on **June 22, 2036**.
+
+**Days remaining:** ${daysUntil}
+
+### Action Required
+
+1. Identify the new root CA certificates from Cloudflare/Google Trust Services
+2. Extract SPKI SHA-256 hashes for the new certificates
+3. Update \`CutiECertificatePinning.swift\` with new hashes
+4. Test thoroughly on sandbox API
+5. Release new SDK version
+6. Notify all SDK users to update
+
+### Resources
+
+- [CERTIFICATE_PINNING.md](./CERTIFICATE_PINNING.md) - Update process documentation
+- [Google Trust Services](https://pki.goog/) - Root CA information
+
+This issue was automatically created by the monthly certificate expiry check.`,
+                labels: ['security', 'certificate-pinning', 'urgent']
+              });
+            }

--- a/CERTIFICATE_PINNING.md
+++ b/CERTIFICATE_PINNING.md
@@ -1,0 +1,180 @@
+# Certificate Pinning
+
+This SDK implements SSL certificate pinning to protect against man-in-the-middle attacks. This document explains the implementation and update process.
+
+## Current Configuration
+
+| Property | Value |
+|----------|-------|
+| Pinned CAs | Google Trust Services Root R1, R2, R3, R4 |
+| Intermediate | WE1 (Cloudflare) |
+| Expiry Date | **June 22, 2036** |
+| Monitoring | Automated CI check (monthly) |
+
+## How It Works
+
+The SDK pins to Google Trust Services root CAs, which are used by Cloudflare for our API endpoints. This is safer than pinning to leaf certificates because:
+
+1. Root CAs have long validity periods (10+ years)
+2. Cloudflare can rotate leaf certificates without breaking the SDK
+3. Users don't need to update the SDK for routine certificate renewals
+
+## Pinned Domains
+
+- `api.cuti-e.com` (production)
+- `cutie-worker-sandbox.invotekas.workers.dev` (sandbox)
+- `invotekas.workers.dev` (workers subdomain)
+
+## Monitoring
+
+### Automated CI Check
+
+A GitHub Actions workflow runs monthly to check pin expiry:
+
+- **Workflow:** `.github/workflows/pin-expiry-check.yml`
+- **Schedule:** 1st of each month at 00:00 UTC
+- **Action:** Creates/updates a GitHub issue when < 1 year remaining
+
+### Runtime Check
+
+The SDK logs a warning at initialization if pins are expiring soon:
+
+```
+[CutiE] WARNING: Certificate pins expire in X days (June 22, 2036). Plan SDK update.
+```
+
+## When to Update
+
+Update certificate pins when:
+
+1. Current pins are within 1 year of expiry
+2. Cloudflare changes their certificate chain
+3. Google Trust Services issues new root CAs
+4. A pinned certificate is compromised (emergency)
+
+## Update Process
+
+### 1. Identify New Certificates
+
+Check which root CAs Cloudflare is currently using:
+
+```bash
+# Get the certificate chain from production API
+openssl s_client -connect api.cuti-e.com:443 -showcerts < /dev/null 2>/dev/null | \
+  openssl x509 -noout -issuer
+```
+
+Visit [Google Trust Services](https://pki.goog/) for current root CA information.
+
+### 2. Extract SPKI Hashes
+
+For each certificate in the chain:
+
+```bash
+# Download the certificate (example for GTS Root R1)
+curl -O https://pki.goog/repo/certs/gtsr1.der
+
+# Convert DER to PEM if needed
+openssl x509 -inform DER -in gtsr1.der -out gtsr1.pem
+
+# Extract SPKI hash
+openssl x509 -in gtsr1.pem -pubkey -noout | \
+  openssl pkey -pubin -outform DER | \
+  openssl dgst -sha256 -binary | \
+  base64
+```
+
+### 3. Update the SDK
+
+Edit `Sources/CutiE/CutiECertificatePinning.swift`:
+
+1. Add new hashes to `pinnedHashes`
+2. Update `pinExpiryDate` to the new expiry date
+3. Update comments with new certificate details
+
+```swift
+private let pinnedHashes: Set<String> = [
+    // NEW: GTS Root RX (add new certificates here)
+    "newHashHere=",
+    // Keep old hashes during transition period
+    "hxqRlPTu1bMS/0DITB1SSu0vd4u/8l8TjPgfaAp63Gc=",
+    // ...
+]
+
+private static let pinExpiryDate: Date = {
+    var components = DateComponents()
+    components.year = 2046  // Update to new expiry year
+    // ...
+}()
+```
+
+### 4. Test Thoroughly
+
+```bash
+# Build and run tests
+swift build
+swift test
+
+# Test against sandbox API
+# (Manual testing in a test app)
+
+# Test against production API
+# (Verify pinning works correctly)
+```
+
+### 5. Release New SDK Version
+
+1. Update version in `Package.swift` if needed
+2. Create PR with changes
+3. After merge, create a new release tag
+4. Update CHANGELOG.md
+
+### 6. Notify SDK Users
+
+- Create a GitHub release with update notes
+- Consider a deprecation warning in the old version
+- Allow transition period (keep old + new hashes)
+
+## Timeline
+
+| Date | Action |
+|------|--------|
+| Monthly | CI checks expiry, creates issue if < 1 year |
+| 1 year before | Start planning certificate update |
+| 6 months before | Release SDK with new pins |
+| 3 months before | Deprecation warnings for old SDK versions |
+| Expiry date | Old pins stop working |
+
+## Troubleshooting
+
+### Connection Failures After Update
+
+If users report connection failures after a certificate update:
+
+1. Verify the new hashes are correct
+2. Check if Cloudflare changed their certificate chain
+3. Temporarily add more root CA hashes to cover edge cases
+4. Release a hotfix SDK version
+
+### Extracting Hashes from Live Server
+
+```bash
+# Get all certificates in the chain
+echo | openssl s_client -connect api.cuti-e.com:443 -showcerts 2>/dev/null | \
+  awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/{ print }' > chain.pem
+
+# Split into individual certificates and hash each one
+```
+
+## Security Considerations
+
+- Never remove old hashes immediately; allow transition period
+- Keep at least 2-3 backup root CA hashes
+- Monitor for certificate chain changes proactively
+- Have an emergency update process ready
+
+## References
+
+- [OWASP Certificate Pinning](https://owasp.org/www-community/controls/Certificate_and_Public_Key_Pinning)
+- [Google Trust Services](https://pki.goog/)
+- [Cloudflare SSL/TLS](https://developers.cloudflare.com/ssl/)


### PR DESCRIPTION
## Summary

Implements automated monitoring for certificate pin expiry to prevent service disruptions.

- Adds expiry date constant (June 22, 2036) to `CutiECertificatePinning`
- Adds `checkPinExpiry()` method that logs warnings if < 1 year remaining
- Adds `daysUntilPinExpiry()` for programmatic access
- Creates monthly CI workflow to check expiry and auto-create issues
- Adds `CERTIFICATE_PINNING.md` with comprehensive update process documentation

## Changes

| File | Change |
|------|--------|
| `CutiECertificatePinning.swift` | Added expiry constants and monitoring methods |
| `.github/workflows/pin-expiry-check.yml` | Monthly CI check with auto-issue creation |
| `CERTIFICATE_PINNING.md` | Update process documentation |

## Test Plan

- [x] `swift build` succeeds
- [x] `swift test` passes (122 tests)
- [ ] CI workflow syntax validated

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)