### PR TITLE
feat: Add SDK version header to API requests

### DIFF
--- a/Sources/CutiE/CutiE.swift
+++ b/Sources/CutiE/CutiE.swift
@@ -8,6 +8,9 @@ import UIKit
 /// Main Cuti-E SDK class
 public class CutiE {
 
+    /// SDK version (matches git tag)
+    internal static let sdkVersion = "1.0.104"
+
     /// Shared singleton instance
     public static let shared = CutiE()
 

--- a/Sources/CutiE/CutiEAPIClient.swift
+++ b/Sources/CutiE/CutiEAPIClient.swift
@@ -91,6 +91,7 @@ internal class CutiEAPIClient {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(CutiE.sdkVersion, forHTTPHeaderField: "X-CutiE-SDK-Version")
         request.setValue(configuration.appId, forHTTPHeaderField: "X-App-ID")
         request.setValue(configuration.deviceID, forHTTPHeaderField: "X-Device-ID")
         // Include API key if available (deprecated, for backwards compatibility)
@@ -688,6 +689,7 @@ internal class CutiEAPIClient {
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(CutiE.sdkVersion, forHTTPHeaderField: "X-CutiE-SDK-Version")
 
         // Use device token if available (preferred)
         if let token = deviceToken {


### PR DESCRIPTION
## Summary
- Add `X-CutiE-SDK-Version` header to all outgoing API requests
- Version constant defined in `CutiE.swift` as single source of truth
- Applied to both `registerDeviceToken` and `performRequest` methods
- No public API changes (internal implementation only)

Closes #52

## Test plan
- [ ] All 122 existing tests pass
- [ ] Verify header appears in network requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)