### PR TITLE
fix(release): Sync sdkVersion with release-please manifest

### DIFF
--- a/Sources/CutiE/CutiE.swift
+++ b/Sources/CutiE/CutiE.swift
@@ -9,7 +9,7 @@ import UIKit
 public class CutiE {
 
     /// SDK version (matches git tag)
-    internal static let sdkVersion = "1.0.104"
+    internal static let sdkVersion = "1.1.0" // x-release-please-version
 
     /// Shared singleton instance
     public static let shared = CutiE()

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,8 @@
     {"type": "ci", "section": "CI/CD", "hidden": true}
   ],
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": ["Sources/CutiE/CutiE.swift"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Update hardcoded `sdkVersion` from "1.0.104" to "1.1.0" (matching current release)
- Add `x-release-please-version` annotation so future releases auto-update the constant
- Configure `extra-files` in release-please-config.json to scan `CutiE.swift`

Closes #55

## Test plan
- [ ] All tests pass (version format validation included)
- [ ] Next release-please PR should update both manifest and CutiE.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)