### PR TITLE
test: Add SDK version header test and sync with release-please

### DIFF
--- a/Sources/CutiE/CutiE.swift
+++ b/Sources/CutiE/CutiE.swift
@@ -8,8 +8,8 @@ import UIKit
 /// Main Cuti-E SDK class
 public class CutiE {
 
-    /// SDK version (matches git tag)
-    internal static let sdkVersion = "1.0.104"
+    /// SDK version (matches git tag, updated by release-please)
+    internal static let sdkVersion = "1.1.0" // x-release-please-version
 
     /// Shared singleton instance
     public static let shared = CutiE()

--- a/Sources/CutiE/CutiEAPIClient.swift
+++ b/Sources/CutiE/CutiEAPIClient.swift
@@ -32,6 +32,12 @@ internal class CutiEAPIClient {
         self.session = CutiECertificatePinning.shared.createPinnedSession(configuration: config)
     }
 
+    /// Internal initializer for testing with a custom URLSession
+    init(configuration: CutiEConfiguration, session: URLSession) {
+        self.configuration = configuration
+        self.session = session
+    }
+
     // MARK: - Keychain Storage for Device Token
 
     private let deviceTokenKeychainKey = "com.cutie.deviceToken"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,13 @@
     {"type": "ci", "section": "CI/CD", "hidden": true}
   ],
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "Sources/CutiE/CutiE.swift"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds URLProtocol-based test verifying `CutiEAPIClient` attaches `X-CutiE-SDK-Version` header to outgoing requests (closes #56)
- Adds internal `init(configuration:session:)` to `CutiEAPIClient` for test session injection
- Syncs `sdkVersion` constant from "1.0.104" to "1.1.0" to match `.release-please-manifest.json` (closes #55)
- Configures `extra-files` in `release-please-config.json` so future releases auto-update the Swift constant via `x-release-please-version` marker

Closes #55
Closes #56

## Test plan
- [x] All 126 tests pass locally via `swift test`
- [x] New `testAPIClientAttachesSDKVersionHeader` verifies header on intercepted requests
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)