### PR TITLE
test: add unit tests for AppAttest, CertificatePinning, and SubscriptionManager

### DIFF
--- a/Tests/CutiETests/AppAttestTests.swift
+++ b/Tests/CutiETests/AppAttestTests.swift
@@ -1,0 +1,262 @@
+import XCTest
+@testable import CutiE
+
+// MARK: - AppAttestError Tests
+
+final class AppAttestErrorTests: XCTestCase {
+
+    func testNotSupportedError() {
+        let error = AppAttestError.notSupported
+        XCTAssertEqual(error.errorDescription, "App Attest is not supported on this device")
+    }
+
+    func testNotAttestedError() {
+        let error = AppAttestError.notAttested
+        XCTAssertEqual(error.errorDescription, "Device not attested. Call performAttestation() first.")
+    }
+
+    func testHashingFailedError() {
+        let error = AppAttestError.hashingFailed
+        XCTAssertEqual(error.errorDescription, "Failed to create client data hash")
+    }
+
+    func testKeyGenerationFailedError() {
+        let error = AppAttestError.keyGenerationFailed
+        XCTAssertEqual(error.errorDescription, "Failed to generate key pair")
+    }
+
+    func testAttestationFailedError() {
+        struct MockError: Error, LocalizedError {
+            var errorDescription: String? { "Apple server rejected" }
+        }
+
+        let error = AppAttestError.attestationFailed(MockError())
+        XCTAssertTrue(error.errorDescription?.contains("Attestation failed") ?? false)
+        XCTAssertTrue(error.errorDescription?.contains("Apple server rejected") ?? false)
+    }
+
+    func testAssertionFailedError() {
+        struct MockError: Error, LocalizedError {
+            var errorDescription: String? { "Key not found" }
+        }
+
+        let error = AppAttestError.assertionFailed(MockError())
+        XCTAssertTrue(error.errorDescription?.contains("Assertion generation failed") ?? false)
+        XCTAssertTrue(error.errorDescription?.contains("Key not found") ?? false)
+    }
+
+    func testServerErrorMessage() {
+        let error = AppAttestError.serverError("Invalid attestation object")
+        XCTAssertEqual(error.errorDescription, "Server error: Invalid attestation object")
+    }
+
+    func testAllErrorsConformToLocalizedError() {
+        let errors: [AppAttestError] = [
+            .notSupported,
+            .notAttested,
+            .hashingFailed,
+            .keyGenerationFailed,
+            .attestationFailed(NSError(domain: "test", code: 0)),
+            .assertionFailed(NSError(domain: "test", code: 0)),
+            .serverError("test")
+        ]
+
+        for error in errors {
+            XCTAssertNotNil(error.errorDescription, "Error \(error) should have errorDescription")
+            XCTAssertFalse(error.errorDescription!.isEmpty)
+        }
+    }
+}
+
+// MARK: - AppAttest Behavior Tests
+
+@available(iOS 14.0, macOS 11.0, *)
+final class AppAttestTests: XCTestCase {
+
+    func testSharedSingleton() {
+        let instance1 = CutiEAppAttest.shared
+        let instance2 = CutiEAppAttest.shared
+        XCTAssertTrue(instance1 === instance2, "shared should return the same instance")
+    }
+
+    func testIsSupportedOnMacOS() {
+        // On macOS test runner / simulator, isSupported should return false
+        // (App Attest requires physical iOS device with Secure Enclave)
+        #if targetEnvironment(simulator) || os(macOS)
+        XCTAssertFalse(CutiEAppAttest.shared.isSupported)
+        #endif
+    }
+
+    func testResetClearsAttestationState() {
+        let appAttest = CutiEAppAttest.shared
+        appAttest.reset()
+        XCTAssertFalse(appAttest.isAttested, "After reset, isAttested should be false")
+    }
+
+    func testGenerateAssertionThrowsNotSupportedOnMacOS() async {
+        #if targetEnvironment(simulator) || os(macOS)
+        let appAttest = CutiEAppAttest.shared
+        let testData = "test payload".data(using: .utf8)!
+
+        do {
+            _ = try await appAttest.generateAssertion(for: testData)
+            XCTFail("Should throw on unsupported platform")
+        } catch let error as AppAttestError {
+            XCTAssertEqual(error.errorDescription, AppAttestError.notSupported.errorDescription)
+        } catch {
+            XCTFail("Expected AppAttestError.notSupported, got \(error)")
+        }
+        #endif
+    }
+}
+
+// MARK: - AppAttest Model Tests
+
+final class AppAttestModelTests: XCTestCase {
+
+    func testAttestationStatusDecoding() throws {
+        let json = """
+        {
+            "attested": true,
+            "attestation": {
+                "key_id": "abc123",
+                "environment": "production",
+                "sign_count": 5,
+                "created_at": 1700000000,
+                "last_assertion_at": 1700001000
+            }
+        }
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(AttestationStatus.self, from: json)
+        XCTAssertTrue(status.attested)
+        XCTAssertNotNil(status.attestation)
+        XCTAssertEqual(status.attestation?.keyId, "abc123")
+        XCTAssertEqual(status.attestation?.environment, "production")
+        XCTAssertEqual(status.attestation?.signCount, 5)
+        XCTAssertEqual(status.attestation?.createdAt, 1700000000)
+        XCTAssertEqual(status.attestation?.lastAssertionAt, 1700001000)
+    }
+
+    func testAttestationStatusDecodingNotAttested() throws {
+        let json = """
+        {
+            "attested": false,
+            "attestation": null
+        }
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(AttestationStatus.self, from: json)
+        XCTAssertFalse(status.attested)
+        XCTAssertNil(status.attestation)
+    }
+
+    func testAttestationInfoDecodingWithoutLastAssertion() throws {
+        let json = """
+        {
+            "key_id": "key456",
+            "environment": "development",
+            "sign_count": 0,
+            "created_at": 1700000000,
+            "last_assertion_at": null
+        }
+        """.data(using: .utf8)!
+
+        let info = try JSONDecoder().decode(AttestationInfo.self, from: json)
+        XCTAssertEqual(info.keyId, "key456")
+        XCTAssertEqual(info.environment, "development")
+        XCTAssertEqual(info.signCount, 0)
+        XCTAssertEqual(info.createdAt, 1700000000)
+        XCTAssertNil(info.lastAssertionAt)
+    }
+
+    func testAttestChallengeResponseDecoding() throws {
+        let json = """
+        {
+            "challenge": "random-challenge-string-abc123",
+            "expires_at": 1700001000,
+            "expires_in": 300
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(AttestChallengeResponse.self, from: json)
+        XCTAssertEqual(response.challenge, "random-challenge-string-abc123")
+        XCTAssertEqual(response.expiresAt, 1700001000)
+        XCTAssertEqual(response.expiresIn, 300)
+    }
+
+    func testAttestResponseDecoding() throws {
+        let json = """
+        {
+            "success": true,
+            "attestation_id": "att_xyz789",
+            "attested": true
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(AttestResponse.self, from: json)
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.attestationId, "att_xyz789")
+        XCTAssertTrue(response.attested)
+    }
+
+    func testAttestResponseDecodingFailure() throws {
+        let json = """
+        {
+            "success": false,
+            "attestation_id": "",
+            "attested": false
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(AttestResponse.self, from: json)
+        XCTAssertFalse(response.success)
+        XCTAssertEqual(response.attestationId, "")
+        XCTAssertFalse(response.attested)
+    }
+}
+
+// MARK: - Data SHA256 Extension Tests
+
+final class DataSHA256Tests: XCTestCase {
+
+    func testSHA256ProducesCorrectLength() {
+        let data = "Hello, World!".data(using: .utf8)!
+        let hash = data.sha256()
+        XCTAssertEqual(hash.count, 32, "SHA-256 should produce 32 bytes")
+    }
+
+    func testSHA256Consistency() {
+        let data = "test data".data(using: .utf8)!
+        let hash1 = data.sha256()
+        let hash2 = data.sha256()
+        XCTAssertEqual(hash1, hash2, "Same input should produce same hash")
+    }
+
+    func testSHA256DifferentInputs() {
+        let data1 = "input one".data(using: .utf8)!
+        let data2 = "input two".data(using: .utf8)!
+        let hash1 = data1.sha256()
+        let hash2 = data2.sha256()
+        XCTAssertNotEqual(hash1, hash2, "Different inputs should produce different hashes")
+    }
+
+    func testSHA256EmptyData() {
+        let data = Data()
+        let hash = data.sha256()
+        XCTAssertEqual(hash.count, 32, "SHA-256 of empty data should still be 32 bytes")
+
+        // Known SHA-256 of empty string: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        let expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        let actual = hash.map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testSHA256KnownVector() {
+        // Known: SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        let data = "abc".data(using: .utf8)!
+        let hash = data.sha256()
+        let hex = hash.map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(hex, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+    }
+}

--- a/Tests/CutiETests/CertificatePinningTests.swift
+++ b/Tests/CutiETests/CertificatePinningTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import CutiE
+
+final class CertificatePinningTests: XCTestCase {
+
+    // MARK: - Domain Pinning Tests
+
+    func testRequiresPinningForProductionDomain() {
+        let pinning = CutiECertificatePinning.shared
+        XCTAssertTrue(pinning.requiresPinning(for: "api.cuti-e.com"))
+    }
+
+    func testRequiresPinningForSandboxDomain() {
+        let pinning = CutiECertificatePinning.shared
+        XCTAssertTrue(pinning.requiresPinning(for: "cutie-worker-sandbox.invotekas.workers.dev"))
+    }
+
+    func testRequiresPinningForWorkersDomain() {
+        let pinning = CutiECertificatePinning.shared
+        XCTAssertTrue(pinning.requiresPinning(for: "invotekas.workers.dev"))
+    }
+
+    func testRequiresPinningForSubdomain() {
+        let pinning = CutiECertificatePinning.shared
+        // Subdomain of a pinned domain should also require pinning
+        XCTAssertTrue(pinning.requiresPinning(for: "sub.api.cuti-e.com"))
+    }
+
+    func testDoesNotRequirePinningForUnrelatedDomain() {
+        let pinning = CutiECertificatePinning.shared
+        XCTAssertFalse(pinning.requiresPinning(for: "google.com"))
+    }
+
+    func testDoesNotRequirePinningForAppleDomain() {
+        let pinning = CutiECertificatePinning.shared
+        XCTAssertFalse(pinning.requiresPinning(for: "api.apple.com"))
+    }
+
+    func testDoesNotRequirePinningForEmptyString() {
+        let pinning = CutiECertificatePinning.shared
+        XCTAssertFalse(pinning.requiresPinning(for: ""))
+    }
+
+    func testDoesNotRequirePinningForPartialMatch() {
+        let pinning = CutiECertificatePinning.shared
+        // "cuti-e.com" alone is NOT in the pinned list (only "api.cuti-e.com" is)
+        XCTAssertFalse(pinning.requiresPinning(for: "cuti-e.com"))
+    }
+
+    func testDoesNotRequirePinningForSimilarDomain() {
+        let pinning = CutiECertificatePinning.shared
+        XCTAssertFalse(pinning.requiresPinning(for: "evil-api.cuti-e.com.attacker.com"))
+    }
+
+    // MARK: - Expiry Monitoring Tests
+
+    func testDaysUntilPinExpiryIsPositive() {
+        // Pins expire June 22, 2036 - should be many years away
+        let days = CutiECertificatePinning.daysUntilPinExpiry()
+        XCTAssertGreaterThan(days, 365 * 9, "Pins should expire more than 9 years from now")
+    }
+
+    func testDaysUntilPinExpiryIsReasonable() {
+        let days = CutiECertificatePinning.daysUntilPinExpiry()
+        // Should be less than ~11 years from now (pins expire 2036)
+        XCTAssertLessThan(days, 365 * 11, "Pins expiry should be within 11 years")
+    }
+
+    func testCheckPinExpiryDoesNotCrash() {
+        // Just verify it doesn't crash - it only logs
+        CutiECertificatePinning.checkPinExpiry()
+    }
+
+    // MARK: - Session Creation Tests
+
+    func testCreatePinnedSessionReturnsSession() {
+        let pinning = CutiECertificatePinning.shared
+        let session = pinning.createPinnedSession()
+        XCTAssertNotNil(session)
+    }
+
+    func testCreatePinnedSessionWithCustomConfig() {
+        let pinning = CutiECertificatePinning.shared
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 30
+        let session = pinning.createPinnedSession(configuration: config)
+        XCTAssertNotNil(session)
+    }
+
+    // MARK: - Singleton Tests
+
+    func testSharedSingleton() {
+        let instance1 = CutiECertificatePinning.shared
+        let instance2 = CutiECertificatePinning.shared
+        XCTAssertTrue(instance1 === instance2, "shared should return the same instance")
+    }
+
+    // MARK: - Certificate Validation Tests
+
+    func testValidateCertificateChainWithNoTrust() {
+        let pinning = CutiECertificatePinning.shared
+
+        // Create an empty trust with no certificates
+        var trust: SecTrust?
+        let policy = SecPolicyCreateBasicX509()
+        SecTrustCreateWithCertificates([] as CFArray, policy, &trust)
+
+        if let trust = trust {
+            // Empty certificate chain should fail validation
+            XCTAssertFalse(pinning.validateCertificateChain(trust))
+        }
+    }
+}

--- a/Tests/CutiETests/SubscriptionManagerTests.swift
+++ b/Tests/CutiETests/SubscriptionManagerTests.swift
@@ -1,0 +1,342 @@
+import XCTest
+@testable import CutiE
+
+// MARK: - SubscriptionTier Tests
+
+final class SubscriptionTierTests: XCTestCase {
+
+    func testRawValues() {
+        XCTAssertEqual(SubscriptionTier.free.rawValue, 0)
+        XCTAssertEqual(SubscriptionTier.starter.rawValue, 1)
+        XCTAssertEqual(SubscriptionTier.pro.rawValue, 2)
+        XCTAssertEqual(SubscriptionTier.business.rawValue, 3)
+    }
+
+    func testDisplayNames() {
+        XCTAssertEqual(SubscriptionTier.free.displayName, "Free")
+        XCTAssertEqual(SubscriptionTier.starter.displayName, "Starter")
+        XCTAssertEqual(SubscriptionTier.pro.displayName, "Pro")
+        XCTAssertEqual(SubscriptionTier.business.displayName, "Business")
+    }
+
+    func testFeedbackLimits() {
+        XCTAssertEqual(SubscriptionTier.free.feedbackLimit, 50)
+        XCTAssertEqual(SubscriptionTier.starter.feedbackLimit, 500)
+        XCTAssertEqual(SubscriptionTier.pro.feedbackLimit, 10_000)
+        XCTAssertEqual(SubscriptionTier.business.feedbackLimit, Int.max)
+    }
+
+    func testComparable() {
+        XCTAssertTrue(SubscriptionTier.free < .starter)
+        XCTAssertTrue(SubscriptionTier.starter < .pro)
+        XCTAssertTrue(SubscriptionTier.pro < .business)
+        XCTAssertFalse(SubscriptionTier.business < .free)
+        XCTAssertFalse(SubscriptionTier.pro < .starter)
+    }
+
+    func testComparableGreaterThanOrEqual() {
+        XCTAssertTrue(SubscriptionTier.business >= .business)
+        XCTAssertTrue(SubscriptionTier.business >= .pro)
+        XCTAssertTrue(SubscriptionTier.pro >= .starter)
+        XCTAssertTrue(SubscriptionTier.starter >= .free)
+        XCTAssertFalse(SubscriptionTier.free >= .starter)
+    }
+
+    func testCodableEncode() throws {
+        let tier = SubscriptionTier.pro
+        let data = try JSONEncoder().encode(tier)
+        let decoded = try JSONDecoder().decode(SubscriptionTier.self, from: data)
+        XCTAssertEqual(decoded, tier)
+    }
+
+    func testCodableDecodeFromRawValue() throws {
+        // Raw value 2 should decode to .pro
+        let json = "2".data(using: .utf8)!
+        let tier = try JSONDecoder().decode(SubscriptionTier.self, from: json)
+        XCTAssertEqual(tier, .pro)
+    }
+
+    func testAllTiersCodableRoundTrip() throws {
+        let tiers: [SubscriptionTier] = [.free, .starter, .pro, .business]
+        for tier in tiers {
+            let data = try JSONEncoder().encode(tier)
+            let decoded = try JSONDecoder().decode(SubscriptionTier.self, from: data)
+            XCTAssertEqual(decoded, tier, "Round trip failed for \(tier.displayName)")
+        }
+    }
+
+    func testFeedbackLimitsIncreaseWithTier() {
+        let tiers: [SubscriptionTier] = [.free, .starter, .pro, .business]
+        for i in 0..<(tiers.count - 1) {
+            XCTAssertLessThan(
+                tiers[i].feedbackLimit,
+                tiers[i + 1].feedbackLimit,
+                "\(tiers[i].displayName) limit should be less than \(tiers[i + 1].displayName)"
+            )
+        }
+    }
+}
+
+// MARK: - SubscriptionStatus Tests
+
+final class SubscriptionStatusTests: XCTestCase {
+
+    func testNoneEquality() {
+        XCTAssertEqual(SubscriptionStatus.none, SubscriptionStatus.none)
+    }
+
+    func testExpiredEquality() {
+        XCTAssertEqual(SubscriptionStatus.expired, SubscriptionStatus.expired)
+    }
+
+    func testActiveWithSameDateEquality() {
+        let date = Date(timeIntervalSince1970: 1700000000)
+        XCTAssertEqual(
+            SubscriptionStatus.active(expiresAt: date),
+            SubscriptionStatus.active(expiresAt: date)
+        )
+    }
+
+    func testActiveWithNilDateEquality() {
+        XCTAssertEqual(
+            SubscriptionStatus.active(expiresAt: nil),
+            SubscriptionStatus.active(expiresAt: nil)
+        )
+    }
+
+    func testActiveWithDifferentDatesNotEqual() {
+        let date1 = Date(timeIntervalSince1970: 1700000000)
+        let date2 = Date(timeIntervalSince1970: 1700001000)
+        XCTAssertNotEqual(
+            SubscriptionStatus.active(expiresAt: date1),
+            SubscriptionStatus.active(expiresAt: date2)
+        )
+    }
+
+    func testGracePeriodEquality() {
+        let date = Date(timeIntervalSince1970: 1700000000)
+        XCTAssertEqual(
+            SubscriptionStatus.gracePeriod(expiresAt: date),
+            SubscriptionStatus.gracePeriod(expiresAt: date)
+        )
+    }
+
+    func testDifferentStatusesNotEqual() {
+        XCTAssertNotEqual(SubscriptionStatus.none, SubscriptionStatus.expired)
+        XCTAssertNotEqual(
+            SubscriptionStatus.none,
+            SubscriptionStatus.active(expiresAt: nil)
+        )
+        XCTAssertNotEqual(
+            SubscriptionStatus.expired,
+            SubscriptionStatus.active(expiresAt: nil)
+        )
+    }
+}
+
+// MARK: - Product ID Tests
+
+@available(iOS 15.0, macOS 12.0, *)
+final class ProductIDTests: XCTestCase {
+
+    func testProductIDsCount() {
+        XCTAssertEqual(CutiESubscriptionManager.productIDs.count, 6)
+    }
+
+    func testProductIDsContainAllTiers() {
+        let ids = CutiESubscriptionManager.productIDs
+        XCTAssertTrue(ids.contains("com.cutie.starter.monthly"))
+        XCTAssertTrue(ids.contains("com.cutie.starter.yearly"))
+        XCTAssertTrue(ids.contains("com.cutie.pro.monthly"))
+        XCTAssertTrue(ids.contains("com.cutie.pro.yearly"))
+        XCTAssertTrue(ids.contains("com.cutie.business.monthly"))
+        XCTAssertTrue(ids.contains("com.cutie.business.yearly"))
+    }
+
+    func testProductIDsDoNotContainFree() {
+        let ids = CutiESubscriptionManager.productIDs
+        let freeIDs = ids.filter { $0.contains("free") }
+        XCTAssertTrue(freeIDs.isEmpty, "Free tier should not have product IDs")
+    }
+
+    func testProductIDsHaveConsistentPrefix() {
+        let ids = CutiESubscriptionManager.productIDs
+        for id in ids {
+            XCTAssertTrue(id.hasPrefix("com.cutie."), "Product ID '\(id)' should start with 'com.cutie.'")
+        }
+    }
+
+    func testProductIDsHaveBillingPeriod() {
+        let ids = CutiESubscriptionManager.productIDs
+        for id in ids {
+            let hasMonthly = id.hasSuffix(".monthly")
+            let hasYearly = id.hasSuffix(".yearly")
+            XCTAssertTrue(hasMonthly || hasYearly, "Product ID '\(id)' should end with .monthly or .yearly")
+        }
+    }
+
+    func testEachTierHasMonthlyAndYearly() {
+        let ids = CutiESubscriptionManager.productIDs
+        let tiers = ["starter", "pro", "business"]
+
+        for tier in tiers {
+            let monthly = ids.contains("com.cutie.\(tier).monthly")
+            let yearly = ids.contains("com.cutie.\(tier).yearly")
+            XCTAssertTrue(monthly, "\(tier) should have monthly product")
+            XCTAssertTrue(yearly, "\(tier) should have yearly product")
+        }
+    }
+}
+
+// MARK: - StoreError Tests
+
+final class StoreErrorTests: XCTestCase {
+
+    func testFailedVerificationError() {
+        let error = StoreError.failedVerification
+        XCTAssertNotNil(error)
+    }
+
+    func testPurchaseFailedError() {
+        let error = StoreError.purchaseFailed
+        XCTAssertNotNil(error)
+    }
+
+    func testStoreErrorsAreDifferent() {
+        // Verify the two error cases are distinguishable
+        let error1 = StoreError.failedVerification
+        let error2 = StoreError.purchaseFailed
+
+        switch error1 {
+        case .failedVerification:
+            break // expected
+        case .purchaseFailed:
+            XCTFail("failedVerification should not match purchaseFailed")
+        }
+
+        switch error2 {
+        case .purchaseFailed:
+            break // expected
+        case .failedVerification:
+            XCTFail("purchaseFailed should not match failedVerification")
+        }
+    }
+}
+
+// MARK: - UsageResponse Tests
+
+final class UsageResponseTests: XCTestCase {
+
+    func testFullResponseDecoding() throws {
+        let json = """
+        {
+            "billing_period": "2026-02",
+            "tier": "pro",
+            "usage": {
+                "feedback_count": 42,
+                "feedback_limit": 10000,
+                "feedback_remaining": 9958,
+                "message_count": 150,
+                "attachment_bytes": 5242880,
+                "storage_limit_bytes": 104857600
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(UsageResponse.self, from: json)
+
+        XCTAssertEqual(response.billingPeriod, "2026-02")
+        XCTAssertEqual(response.tier, "pro")
+        XCTAssertEqual(response.usage.feedbackCount, 42)
+        XCTAssertEqual(response.usage.feedbackLimit, 10000)
+        XCTAssertEqual(response.usage.feedbackRemaining, 9958)
+        XCTAssertEqual(response.usage.messageCount, 150)
+        XCTAssertEqual(response.usage.attachmentBytes, 5242880)
+        XCTAssertEqual(response.usage.storageLimitBytes, 104857600)
+    }
+
+    func testFreeUsageResponse() throws {
+        let json = """
+        {
+            "billing_period": "2026-02",
+            "tier": "free",
+            "usage": {
+                "feedback_count": 0,
+                "feedback_limit": 50,
+                "feedback_remaining": 50,
+                "message_count": 0,
+                "attachment_bytes": 0,
+                "storage_limit_bytes": 10485760
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(UsageResponse.self, from: json)
+
+        XCTAssertEqual(response.tier, "free")
+        XCTAssertEqual(response.usage.feedbackCount, 0)
+        XCTAssertEqual(response.usage.feedbackRemaining, 50)
+    }
+
+    func testBusinessUsageResponse() throws {
+        let json = """
+        {
+            "billing_period": "2026-01",
+            "tier": "business",
+            "usage": {
+                "feedback_count": 5000,
+                "feedback_limit": 2147483647,
+                "feedback_remaining": 2147478647,
+                "message_count": 25000,
+                "attachment_bytes": 52428800,
+                "storage_limit_bytes": 1073741824
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(UsageResponse.self, from: json)
+
+        XCTAssertEqual(response.tier, "business")
+        XCTAssertEqual(response.usage.feedbackCount, 5000)
+        XCTAssertEqual(response.usage.storageLimitBytes, 1073741824)
+    }
+}
+
+// MARK: - SubscriptionManager Singleton Tests
+
+@available(iOS 15.0, macOS 12.0, *)
+final class SubscriptionManagerSingletonTests: XCTestCase {
+
+    func testSharedSingleton() {
+        let instance1 = CutiESubscriptionManager.shared
+        let instance2 = CutiESubscriptionManager.shared
+        XCTAssertTrue(instance1 === instance2, "shared should return the same instance")
+    }
+
+    func testDefaultTierIsFree() {
+        // Fresh singleton should default to free tier
+        // Note: This tests the published property's initial value
+        let manager = CutiESubscriptionManager.shared
+        // We can't reset the singleton, but we can verify it has a valid tier
+        XCTAssertNotNil(manager.currentTier)
+        XCTAssertTrue(manager.currentTier.rawValue >= 0)
+        XCTAssertTrue(manager.currentTier.rawValue <= 3)
+    }
+
+    func testDefaultStatusIsValid() {
+        let manager = CutiESubscriptionManager.shared
+        // Status should be one of the valid values
+        switch manager.subscriptionStatus {
+        case .none, .expired:
+            break // Valid default states
+        case .active, .gracePeriod:
+            break // Also valid if there's an active subscription
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add 70 new unit tests covering three previously untested security-sensitive and revenue-critical SDK components
- **AppAttestTests** (23 tests): error enum descriptions, model JSON decoding, SHA256 extension with known vectors, platform fallback on macOS/simulator, reset state management
- **CertificatePinningTests** (16 tests): domain pinning matching (exact + subdomain), non-pinned domain rejection, pin expiry monitoring, session creation, empty certificate chain validation
- **SubscriptionManagerTests** (31 tests): SubscriptionTier enum (raw values, Comparable, Codable round-trip, display names, feedback limits), SubscriptionStatus Equatable, product ID validation, StoreError, UsageResponse JSON decoding

### Coverage Impact (per-file)

| File | Before | After |
|------|--------|-------|
| CutiEAppAttest.swift | ~0% | 53.10% |
| CutiECertificatePinning.swift | ~0% | 33.13% |
| CutiESubscriptionManager.swift | ~0% | 27.24% |

Remaining uncovered code is hardware-dependent (DCAppAttestService, StoreKit purchases, TLS handshakes).

Closes #63

## Test plan

- [x] All 195 tests pass locally on macOS (`xcodebuild test -scheme CutiE -destination 'platform=macOS'`)
- [x] 0 failures, 1 skip (existing integration test gated on env vars)
- [ ] CI passes on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)