### PR TITLE
ci: deploy DocC documentation to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,5 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath .build
 
-      # Note: Upload disabled - DocC generates filenames with colons (Swift function signatures)
-      # which are invalid on Windows/NTFS and rejected by actions/upload-artifact
+      # Deployment handled by deploy-docs.yml (uses actions/upload-pages-artifact
+      # which creates tar archives, bypassing the colon-in-filename issue)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,55 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy DocC to GitHub Pages
+    runs-on: [self-hosted, macOS, ios]
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build DocC Documentation
+        run: |
+          xcodebuild docbuild \
+            -scheme CutiE \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath .build \
+            -skipPackagePluginValidation
+
+      - name: Transform for Static Hosting
+        run: |
+          ARCHIVE=$(find .build -name "*.doccarchive" -type d | head -1)
+          echo "Found archive: $ARCHIVE"
+
+          $(xcrun --find docc) process-archive transform-for-static-hosting \
+            "$ARCHIVE" \
+            --hosting-base-path ios-sdk \
+            --output-path docs
+
+          echo "Generated $(find docs -type f | wc -l | tr -d ' ') files"
+
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ MIT License - See LICENSE file for details
 
 - 📧 Email: <support@cuti-e.com>
 - 🌐 Website: <https://cuti-e.com>
+- 📖 API Reference: <https://cuti-e.github.io/ios-sdk/documentation/cutie/>
 - 📚 Docs: <https://cuti-e.com/docs/>
 
 ---


### PR DESCRIPTION
## Summary

- Add `deploy-docs.yml` workflow that auto-deploys DocC to GitHub Pages on push to main
- Uses `actions/upload-pages-artifact` (tar archive) to bypass the colon-in-filename issue that blocked `actions/upload-artifact` (4686 files with colons from Swift function signatures)
- Enabled GitHub Pages with Actions source on the repo
- Add API reference link to README

### Workflow

```
push to main → xcodebuild docbuild → docc transform-for-static-hosting → upload-pages-artifact → deploy-pages
```

### URL

Documentation will be live at: https://cuti-e.github.io/ios-sdk/documentation/cutie/

Closes #62

## Test plan

- [x] Verified locally: `xcodebuild docbuild` + `docc process-archive transform-for-static-hosting` produces valid static site
- [x] Confirmed `actions/upload-pages-artifact` handles colon-containing filenames (uses tar internally)
- [x] GitHub Pages enabled on repo (`build_type: workflow`)
- [ ] CI passes on PR
- [ ] After merge: verify docs are live at https://cuti-e.github.io/ios-sdk/documentation/cutie/

🤖 Generated with [Claude Code](https://claude.com/claude-code)