### PR TITLE
fix(ci): install GNU tar for macOS Pages deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,11 @@ jobs:
 
           echo "Generated $(find docs -type f | wc -l | tr -d ' ') files"
 
+      - name: Install GNU tar
+        run: |
+          brew list gnu-tar &>/dev/null || brew install gnu-tar
+          echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> $GITHUB_PATH
+
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

- Fix `gtar: command not found` error in deploy-docs workflow
- `actions/upload-pages-artifact` requires GNU tar (`gtar`) which isn't available on macOS self-hosted runners
- Install via Homebrew and add to PATH before the upload step

## Test plan

- [ ] CI passes
- [ ] Deploy Documentation workflow succeeds after merge
- [ ] Docs live at https://cuti-e.github.io/ios-sdk/documentation/cutie/

🤖 Generated with [Claude Code](https://claude.com/claude-code)