### PR TITLE
feat: Add deep-link navigation support to inbox and conversation views

### DIFF
--- a/Sources/CutiE/CutiE.swift
+++ b/Sources/CutiE/CutiE.swift
@@ -254,15 +254,17 @@ public class CutiE {
     // MARK: - Inbox UI
 
     /// Present the inbox view modally
-    /// - Parameter from: The view controller to present from (optional, will find topmost if nil)
+    /// - Parameters:
+    ///   - viewController: The view controller to present from (optional, will find topmost if nil)
+    ///   - conversationId: If provided, automatically navigates to this conversation
     @available(iOS 15.0, *)
-    public func showInbox(from viewController: UIViewController? = nil) {
+    public func showInbox(from viewController: UIViewController? = nil, conversationId: String? = nil) {
         guard isConfigured else {
             NSLog("[CutiE] Cannot show inbox: SDK not configured")
             return
         }
 
-        let inboxView = CutiEInboxView()
+        let inboxView = CutiEInboxView(conversationId: conversationId)
         let hostingController = UIHostingController(rootView: inboxView)
         hostingController.modalPresentationStyle = .pageSheet
 


### PR DESCRIPTION
## Summary

- **CutiEInboxView** now accepts optional `conversationId` parameter — when provided, auto-navigates to that conversation after loading the inbox list
- **CutiEConversationView** now accepts optional `targetMessageId` parameter — when provided, scrolls to that specific message (centered) instead of the last message
- **CutiE.showInbox()** updated to pass through `conversationId` for UIKit host apps
- `getConversation(id:)` already existed — no changes needed

All parameters default to `nil`, preserving full backwards compatibility. No breaking changes.

## How host apps use this

```swift
// Nutri-E: notification tap → open inbox, auto-navigate to conversation
CutiEInboxView(conversationId: "conv_abc123")

// Cutie: notification tap → open conversation, scroll to message
let conv = try await CutiE.shared.getConversation(id: "conv_abc123")
CutiEConversationView(conversation: conv, targetMessageId: "msg_xyz789")

// UIKit: modal presentation with deep-link
CutiE.shared.showInbox(conversationId: "conv_abc123")
```

## Test plan

- [x] `swift build` compiles successfully
- [x] All 164 existing tests pass (0 failures)
- [ ] Manual: verify `CutiEInboxView()` with no params still shows inbox list as before
- [ ] Manual: verify `CutiEInboxView(conversationId:)` auto-navigates to conversation
- [ ] Manual: verify `CutiEConversationView` without targetMessageId scrolls to last message
- [ ] Manual: verify `CutiEConversationView` with targetMessageId scrolls to that message

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)