### PR TITLE
feat: add anonymous activity tracking with consent

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "CutiE"),
+            name: "CutiE",
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
         .testTarget(
             name: "CutiETests",
             dependencies: ["CutiE"]),

--- a/Sources/CutiE/CutiE.swift
+++ b/Sources/CutiE/CutiE.swift
@@ -349,7 +349,7 @@ public class CutiE {
 
         if let sheet = hostingController.sheetPresentationController {
             sheet.detents = [.medium()]
-            sheet.prefersGrabberIndicator = true
+            sheet.prefersGrabberVisible = true
         }
 
         let presenter = viewController ?? Self.topViewController()

--- a/Sources/CutiE/CutiEAnalytics.swift
+++ b/Sources/CutiE/CutiEAnalytics.swift
@@ -1,0 +1,150 @@
+import Foundation
+import CommonCrypto
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Manages anonymous activity tracking with user consent (GDPR-compliant).
+///
+/// Activity pings are fire-and-forget — failures are silently ignored.
+/// The hashed device ID is pseudonymized (SHA256 of identifierForVendor + bundleID).
+/// Consent is opt-in (default OFF) and persisted in UserDefaults.
+internal class CutiEAnalytics {
+
+    static let shared = CutiEAnalytics()
+
+    // MARK: - UserDefaults Keys
+
+    private let consentKey = "com.cutie.analyticsConsent"
+    private let consentAskedKey = "com.cutie.analyticsConsentAsked"
+
+    // MARK: - State
+
+    /// Whether the user has granted analytics consent
+    var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: consentKey) }
+        set {
+            UserDefaults.standard.set(newValue, forKey: consentKey)
+            UserDefaults.standard.set(true, forKey: consentAskedKey)
+            if newValue {
+                startObservingLifecycle()
+                sendActivityPingIfNeeded()
+            } else {
+                stopObservingLifecycle()
+            }
+        }
+    }
+
+    /// Whether the user has been asked for analytics consent
+    var hasBeenAsked: Bool {
+        UserDefaults.standard.bool(forKey: consentAskedKey)
+    }
+
+    /// Prevents sending more than one ping per app launch
+    private var hasSentPingThisLaunch = false
+
+    /// Whether lifecycle observer is active
+    private var isObserving = false
+
+    private init() {}
+
+    // MARK: - SDK Lifecycle
+
+    /// Called from CutiE.configure() after SDK is ready.
+    /// Starts lifecycle observation if consent was previously granted.
+    func onSDKConfigured() {
+        if isEnabled {
+            startObservingLifecycle()
+            sendActivityPingIfNeeded()
+        }
+    }
+
+    // MARK: - Lifecycle Observation
+
+    private func startObservingLifecycle() {
+        guard !isObserving else { return }
+        isObserving = true
+
+        #if os(iOS)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        #endif
+    }
+
+    private func stopObservingLifecycle() {
+        guard isObserving else { return }
+        isObserving = false
+
+        #if os(iOS)
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        #endif
+    }
+
+    @objc private func appDidBecomeActive() {
+        sendActivityPingIfNeeded()
+    }
+
+    // MARK: - Activity Ping
+
+    func sendActivityPingIfNeeded() {
+        guard isEnabled else { return }
+        guard !hasSentPingThisLaunch else { return }
+        guard let client = CutiE.shared.apiClient else { return }
+
+        hasSentPingThisLaunch = true
+
+        let hashedID = generateHashedDeviceID()
+        client.sendActivityPing(hashedDeviceID: hashedID)
+    }
+
+    // MARK: - Hashed Device ID
+
+    /// Generate a SHA256 hash of identifierForVendor + bundleID.
+    /// Returns a 64-character hex string. Falls back to the SDK device ID if
+    /// identifierForVendor is unavailable (e.g., on macOS or simulator edge cases).
+    func generateHashedDeviceID() -> String {
+        var base: String
+
+        #if os(iOS)
+        if let vendorID = UIDevice.current.identifierForVendor?.uuidString {
+            base = vendorID
+        } else {
+            base = CutiE.shared.configuration?.deviceID ?? UUID().uuidString
+        }
+        #else
+        base = CutiE.shared.configuration?.deviceID ?? UUID().uuidString
+        #endif
+
+        if let bundleID = Bundle.main.bundleIdentifier {
+            base += bundleID
+        }
+
+        guard let data = base.data(using: .utf8) else { return "" }
+
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+        }
+
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Testing Support
+
+    /// Reset state for unit tests
+    internal func resetForTesting() {
+        hasSentPingThisLaunch = false
+        stopObservingLifecycle()
+        UserDefaults.standard.removeObject(forKey: consentKey)
+        UserDefaults.standard.removeObject(forKey: consentAskedKey)
+    }
+}

--- a/Sources/CutiE/PrivacyInfo.xcprivacy
+++ b/Sources/CutiE/PrivacyInfo.xcprivacy
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/CutiE/Views/CutiEAnalyticsConsentView.swift
+++ b/Sources/CutiE/Views/CutiEAnalyticsConsentView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+#if os(iOS)
+/// Internal consent sheet for anonymous activity tracking.
+/// Presented via ``CutiE/requestAnalyticsConsent(from:completion:)``.
+@available(iOS 15.0, *)
+internal struct CutiEAnalyticsConsentView: View {
+
+    let appName: String
+    let onDecision: (Bool) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "chart.bar.xaxis.ascending")
+                .font(.system(size: 48))
+                .foregroundColor(.accentColor)
+
+            Text("Help Improve \(appName)")
+                .font(.title2)
+                .fontWeight(.semibold)
+                .multilineTextAlignment(.center)
+
+            Text("Allow anonymous usage data to help us understand how the app is used. No personal information is collected — only a one-time daily activity signal.")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Spacer()
+
+            VStack(spacing: 12) {
+                Button {
+                    onDecision(true)
+                    dismiss()
+                } label: {
+                    Text("Allow")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    onDecision(false)
+                    dismiss()
+                } label: {
+                    Text("Not Now")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 24)
+        }
+        .padding()
+    }
+}
+#endif

--- a/Tests/CutiETests/AnalyticsTests.swift
+++ b/Tests/CutiETests/AnalyticsTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import CutiE
+
+final class AnalyticsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        CutiEAnalytics.shared.resetForTesting()
+    }
+
+    override func tearDown() {
+        CutiEAnalytics.shared.resetForTesting()
+        super.tearDown()
+    }
+
+    // MARK: - Default State
+
+    func testDefaultStateIsDisabled() {
+        XCTAssertFalse(CutiEAnalytics.shared.isEnabled)
+    }
+
+    func testDefaultConsentNotAsked() {
+        XCTAssertFalse(CutiEAnalytics.shared.hasBeenAsked)
+    }
+
+    // MARK: - Consent Persistence
+
+    func testEnableAnalyticsPersists() {
+        CutiEAnalytics.shared.isEnabled = true
+        XCTAssertTrue(CutiEAnalytics.shared.isEnabled)
+        XCTAssertTrue(CutiEAnalytics.shared.hasBeenAsked)
+    }
+
+    func testDisableAnalyticsPersists() {
+        CutiEAnalytics.shared.isEnabled = true
+        CutiEAnalytics.shared.isEnabled = false
+        XCTAssertFalse(CutiEAnalytics.shared.isEnabled)
+        XCTAssertTrue(CutiEAnalytics.shared.hasBeenAsked, "hasBeenAsked should stay true after withdrawal")
+    }
+
+    func testConsentWithdrawal() {
+        // Grant
+        CutiEAnalytics.shared.isEnabled = true
+        XCTAssertTrue(CutiEAnalytics.shared.isEnabled)
+
+        // Withdraw
+        CutiEAnalytics.shared.isEnabled = false
+        XCTAssertFalse(CutiEAnalytics.shared.isEnabled)
+        XCTAssertTrue(CutiEAnalytics.shared.hasBeenAsked)
+    }
+
+    // MARK: - Hashed Device ID
+
+    func testHashedDeviceIDIs64CharHex() {
+        // Configure SDK so deviceID is stable
+        CutiE.shared.configure(appId: "app_test", apiURL: "https://test.api.com")
+
+        let hashedID = CutiEAnalytics.shared.generateHashedDeviceID()
+        XCTAssertEqual(hashedID.count, 64, "SHA256 hex digest must be 64 characters")
+
+        let hexChars = CharacterSet(charactersIn: "0123456789abcdef")
+        XCTAssertTrue(
+            hashedID.unicodeScalars.allSatisfy { hexChars.contains($0) },
+            "Hashed ID must contain only hex characters"
+        )
+    }
+
+    func testHashedDeviceIDIsConsistent() {
+        // Configure SDK so deviceID is stable
+        CutiE.shared.configure(appId: "app_test", apiURL: "https://test.api.com")
+
+        let id1 = CutiEAnalytics.shared.generateHashedDeviceID()
+        let id2 = CutiEAnalytics.shared.generateHashedDeviceID()
+        XCTAssertEqual(id1, id2, "Hashed device ID must be deterministic")
+    }
+
+    // MARK: - Public API Delegation
+
+    func testPublicAPIDelegatesToAnalytics() {
+        let cutiE = CutiE.shared
+
+        XCTAssertFalse(cutiE.analyticsEnabled)
+        XCTAssertFalse(cutiE.hasAskedForAnalyticsConsent)
+
+        cutiE.setAnalyticsConsent(true)
+        XCTAssertTrue(cutiE.analyticsEnabled)
+        XCTAssertTrue(cutiE.hasAskedForAnalyticsConsent)
+
+        cutiE.setAnalyticsConsent(false)
+        XCTAssertFalse(cutiE.analyticsEnabled)
+    }
+
+    // MARK: - Safety Without Configuration
+
+    func testNoCrashWithoutConfiguration() {
+        // Ensure SDK is not configured
+        let savedConfig = CutiE.shared.configuration
+        let savedClient = CutiE.shared.apiClient
+        CutiE.shared.configuration = nil
+        CutiE.shared.apiClient = nil
+
+        // Enable analytics and trigger ping — should not crash
+        CutiEAnalytics.shared.isEnabled = true
+        CutiEAnalytics.shared.sendActivityPingIfNeeded()
+
+        // Restore
+        CutiE.shared.configuration = savedConfig
+        CutiE.shared.apiClient = savedClient
+    }
+
+    func testNoPingWithoutConsent() {
+        // Configure SDK
+        CutiE.shared.configure(appId: "app_test", apiURL: "https://test.api.com")
+
+        // Without consent, sendActivityPingIfNeeded should be a no-op
+        // (we can't easily verify no network call, but at least no crash)
+        CutiEAnalytics.shared.sendActivityPingIfNeeded()
+        XCTAssertFalse(CutiEAnalytics.shared.isEnabled)
+    }
+}


### PR DESCRIPTION
## Summary

- Add opt-in anonymous activity tracking (DAU/WAU/MAU) to the CutiE iOS SDK
- `CutiEAnalytics` singleton manages consent state, hashed device ID (SHA256), lifecycle observation, and per-launch ping deduplication
- Fire-and-forget `sendActivityPing()` bypasses normal request pipeline — silently ignores all errors
- Public API: `analyticsEnabled`, `setAnalyticsConsent()`, `hasAskedForAnalyticsConsent`, `requestAnalyticsConsent()` (iOS 15+ consent sheet)
- Apple `PrivacyInfo.xcprivacy` declares Device ID for analytics (not linked, not tracking)
- GDPR compliant: opt-in (default OFF), persistent consent, supports withdrawal

### New files
| File | Purpose |
|------|---------|
| `CutiEAnalytics.swift` | Core analytics manager (singleton) |
| `CutiEAnalyticsConsentView.swift` | SwiftUI consent half-sheet |
| `PrivacyInfo.xcprivacy` | Apple privacy manifest |
| `AnalyticsTests.swift` | 10 unit tests |

### Modified files
| File | Change |
|------|--------|
| `CutiEAPIClient.swift` | Added `sendActivityPing()` fire-and-forget method |
| `CutiE.swift` | Public analytics API + `configure()` hook |
| `Package.swift` | Privacy manifest resource bundle |

Closes cuti-e/ios-sdk#79

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (174 tests, 0 failures)
- [x] Privacy manifest included in build output
- [ ] CI checks pass
- [ ] Copilot review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)