### PR TITLE
chore: remove old docs deploy — use unified site only

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,72 +1,19 @@
-name: Deploy Documentation
+name: Deploy Docs
 
 on:
   push:
     branches: [main]
-
-permissions:
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
+    paths: ["docs/**"]
+  workflow_dispatch:
 
 jobs:
-  deploy:
-    name: Deploy DocC to GitHub Pages
-    runs-on: [self-hosted, macOS, ios]
-    timeout-minutes: 15
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build DocC Documentation
-        run: |
-          xcodebuild docbuild \
-            -scheme CutiE \
-            -destination 'generic/platform=iOS Simulator' \
-            -derivedDataPath .build \
-            -skipPackagePluginValidation
-
-      - name: Transform for Static Hosting
-        run: |
-          ARCHIVE=$(find .build -name "*.doccarchive" -type d | head -1)
-          echo "Found archive: $ARCHIVE"
-
-          $(xcrun --find docc) process-archive transform-for-static-hosting \
-            "$ARCHIVE" \
-            --hosting-base-path ios-sdk \
-            --output-path docs
-
-          echo "Generated $(find docs -type f | wc -l | tr -d ' ') files"
-
-      - name: Install GNU tar
-        run: |
-          brew list gnu-tar &>/dev/null || brew install gnu-tar
-          echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> $GITHUB_PATH
-
-      - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: docs
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-
   notify-unified-docs:
-    needs: deploy
     runs-on: arc-linux-ios-sdk
     steps:
       - name: Trigger unified docs rebuild
         run: |
-          gh api repos/Stig-Johnny/claude-3/dispatches \
-            -f event_type=docs-updated \
+          gh api repos/Stig-Johnny/claude-3/dispatches \\
+            -f event_type=docs-updated \\
             -f 'client_payload[repo]=${{ github.repository }}'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Old per-app CF Pages site has been deleted. This workflow now only triggers the unified docs rebuild on claude-3.