### PR TITLE
ci: migrate workflows from arc-linux-ios-sdk to ubuntu-latest

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   auto-merge:
     name: Auto-merge Dependabot
-    runs-on: arc-linux-ios-sdk
+    runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     permissions:
       pull-requests: write

--- a/.github/workflows/build-status-to-discord.yml
+++ b/.github/workflows/build-status-to-discord.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   notify-thread:
     name: Post Workflow Status
-    runs-on: arc-linux-ios-sdk
+    runs-on: ubuntu-latest
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.pull_requests[0]

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   notify-unified-docs:
-    runs-on: arc-linux-ios-sdk
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger unified docs rebuild
         run: |

--- a/.github/workflows/pr-comments-to-discord.yml
+++ b/.github/workflows/pr-comments-to-discord.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   notify-thread:
     name: Forward to Discord Thread
-    runs-on: arc-linux-ios-sdk
+    runs-on: ubuntu-latest
     if: >-
       github.actor != 'github-actions[bot]'
     permissions:

--- a/.github/workflows/pr-lifecycle-to-discord.yml
+++ b/.github/workflows/pr-lifecycle-to-discord.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   notify-merged:
     name: Post Merge Status
-    runs-on: arc-linux-ios-sdk
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     permissions:
       pull-requests: read

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   request-review:
     name: Request Review-E
-    runs-on: arc-linux-ios-sdk
+    runs-on: ubuntu-latest
     if: >-
       !github.event.pull_request.draft &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&


### PR DESCRIPTION
Closes #100

## Summary
One-line change per file: `runs-on: arc-linux-ios-sdk` → `runs-on: ubuntu-latest`. 6 references across the affected workflows.

## Why
ARC scale set is offline — PRs have been stuck in 24h queue timeout. ubuntu-latest is already documented as the target.

## Verification
```
$ grep -rE 'runs-on:.*arc-linux' .github/workflows/
(no matches)
```

## Test plan
- [ ] CI runs on ubuntu-latest without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)