### PR TITLE
ci: move off self-hosted macOS runner to GitHub-hosted (macos-26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: [self-hosted, macOS, ios]
+    runs-on: macos-26
     timeout-minutes: 10
 
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   test:
     name: Test with Coverage
-    runs-on: [self-hosted, macOS, ios]
+    runs-on: macos-26
     timeout-minutes: 15
 
     steps:
@@ -89,7 +89,7 @@ jobs:
 
   docs:
     name: Build Documentation
-    runs-on: [self-hosted, macOS, ios]
+    runs-on: macos-26
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/pin-expiry-check.yml
+++ b/.github/workflows/pin-expiry-check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-expiry:
-    runs-on: [self-hosted, macOS, ios]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
@@ -17,8 +17,8 @@ jobs:
         run: |
           # Certificate pins expire June 22, 2036
           EXPIRY_DATE="2036-06-22"
-          # macOS BSD date syntax
-          EXPIRY_EPOCH=$(date -j -f "%Y-%m-%d" "$EXPIRY_DATE" +%s)
+          # epoch seconds (GNU date on ubuntu-latest)
+          EXPIRY_EPOCH=$(date -d "$EXPIRY_DATE" +%s)
           NOW_EPOCH=$(date +%s)
           DAYS_UNTIL=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: [self-hosted, macOS, ios]
+    runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
         with:


### PR DESCRIPTION
ios-sdk CI off the self-hosted runner → GitHub-hosted (zero maintenance; the self-hosted runner being absent is what caused today's 24h-queue-cancel). `ci.yml`→`macos-26` (Xcode), `release-please`/`pin-expiry-check`→`ubuntu-latest`. After macos-26 CI is verified green here, I'll retire the Mac Mini runner + update docs.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)